### PR TITLE
Barevent

### DIFF
--- a/backtest/backtest.py
+++ b/backtest/backtest.py
@@ -92,11 +92,15 @@ class Backtest(object):
         print("Running Backtest...")
         iters = 0
         ticks = 0
+        bars = 0
         while iters < self.max_iters and self.price_handler.continue_backtest:
             try:
                 event = self.events_queue.get(False)
             except queue.Empty:
-                self.price_handler.stream_next_tick()
+                if self.price_handler.type == "TICK_HANDLER":
+                    self.price_handler.stream_next_tick()
+                else:
+                    self.price_handler.stream_next_bar()
             else:
                 if event is not None:
                     if event.type == 'TICK':
@@ -106,6 +110,13 @@ class Backtest(object):
                         self.strategy.calculate_signals(event)
                         self.portfolio_handler.update_portfolio_value()
                         ticks += 1
+                    elif event.type == 'BAR':
+                        self.cur_time = event.time
+                        print("Bar %s, at %s" % (bars, self.cur_time))
+                        self._append_equity_state()
+                        self.strategy.calculate_signals(event)
+                        self.portfolio_handler.update_portfolio_value()
+                        bars += 1
                     elif event.type == 'SIGNAL':
                         self.portfolio_handler.on_signal(event)
                     elif event.type == 'ORDER':
@@ -125,3 +136,4 @@ class Backtest(object):
         statistics = Statistics()
         statistics.generate_results()
         statistics.plot_results()
+        

--- a/event/event.py
+++ b/event/event.py
@@ -44,6 +44,99 @@ class TickEvent(Event):
         return str(self)
 
 
+class BarEvent(Event):
+    """
+    Handles the event of receiving a new market
+    open-high-low-close-volume bar, as would be generated 
+    via common data providers such as Yahoo Finance.
+    """
+    def __init__(
+        self, ticker, time, period, 
+        open_price, high_price, low_price, 
+        close_price, volume, adj_close_price=None
+    ):
+        """
+        Initialises the BarEvent.
+
+        Parameters:
+        ticker - The ticker symbol, e.g. 'GOOG'.
+        time - The timestamp of the bar
+        period - The time period covered by the bar in seconds
+        open_price - The unadjusted opening price of the bar
+        high_price - The unadjusted high price of the bar
+        low_price - The unadjusted low price of the bar
+        close_price - The unadjusted close price of the bar
+        volume - The volume of trading within the bar
+        adj_close_price - The vendor adjusted closing price 
+            (e.g. back-adjustment) of the bar
+
+        Note: It is not advised to use 'open', 'close' instead
+        of 'open_price', 'close_price' as 'open' is a reserved
+        word in Python.
+        """
+        self.type = 'BAR'
+        self.ticker = ticker
+        self.time = time
+        self.period = period
+        self.open_price = open_price
+        self.high_price = high_price
+        self.low_price = low_price
+        self.close_price = close_price
+        self.volume = volume
+        self.adj_close_price = adj_close_price
+        self.period_readable = self._readable_period()
+
+    def _readable_period(self):
+        """
+        Creates a human-readable period from the number
+        of seconds specified for 'period'.
+
+        For instance, converts:
+        * 1 -> '1sec'
+        * 5 -> '5secs'
+        * 60 -> '1min'
+        * 300 -> '5min'
+
+        If no period is found in the lookup table, the human
+        readable period is simply passed through from period,
+        in seconds.
+        """
+        lut = {
+            1: "1sec",
+            5: "5sec",
+            10: "10sec",
+            15: "15sec",
+            30: "30sec",
+            60: "1min",
+            300: "5min",
+            600: "10min",
+            900: "15min",
+            1800: "30min",
+            3600: "1hr",
+            86400: "1day",
+            604800: "1wk"
+        }
+        if self.period in lut:
+            return lut[self.period]
+        else:
+            return "%ssec" % str(self.period)
+
+    def __str__(self):
+        format_str = "Type: %s, Ticker: %s, Time: %s, Period: %s, " \
+            "Open: %s, High: %s, Low: %s, Close: %s, " \
+            "Adj Close: %s, Volume: %s" % (
+                str(self.type), str(self.ticker), str(self.time),
+                str(self.period_readable), str(self.open_price),
+                str(self.high_price), str(self.low_price),
+                str(self.close_price), str(self.adj_close_price),
+                str(self.volume)
+            )
+        return format_str
+
+    def __repr__(self):
+        return str(self)
+
+
 class SignalEvent(Event):
     """
     Handles the event of sending a Signal from a Strategy object.

--- a/examples/test_mac_backtest.py
+++ b/examples/test_mac_backtest.py
@@ -1,0 +1,23 @@
+from decimal import Decimal
+
+from qstrader.backtest.backtest import Backtest
+from qstrader.execution_handler.execution_handler import IBSimulatedExecutionHandler
+from qstrader.portfolio_handler.portfolio_handler import PortfolioHandler
+from qstrader.position_sizer.position_sizer import TestPositionSizer
+from qstrader.price_handler.yahoo_price_handler import YahooDailyBarPriceHandler
+from qstrader.risk_manager.risk_manager import TestRiskManager
+from qstrader import settings
+from qstrader.strategy.moving_average_cross_strategy import MovingAverageCrossStrategy
+
+
+if __name__ == "__main__":
+    tickers = ["AAPL"]
+
+    backtest = Backtest(
+        tickers, YahooDailyBarPriceHandler, 
+        MovingAverageCrossStrategy, PortfolioHandler, 
+        IBSimulatedExecutionHandler,
+        TestPositionSizer, TestRiskManager, 
+        equity=Decimal("500000.00")
+    )
+    backtest.simulate_trading()

--- a/examples/test_sp500tr_buy_and_hold_backtest.py
+++ b/examples/test_sp500tr_buy_and_hold_backtest.py
@@ -4,7 +4,7 @@ from qstrader.backtest.backtest import Backtest
 from qstrader.execution_handler.execution_handler import IBSimulatedExecutionHandler
 from qstrader.portfolio_handler.portfolio_handler import PortfolioHandler
 from qstrader.position_sizer.position_sizer import TestPositionSizer
-from qstrader.price_handler.price_handler import YahooDailyBarPriceHandler
+from qstrader.price_handler.yahoo_price_handler import YahooDailyBarPriceHandler
 from qstrader.risk_manager.risk_manager import TestRiskManager
 from qstrader import settings
 from qstrader.strategy.strategy import BuyAndHoldStrategy

--- a/execution_handler/execution_handler.py
+++ b/execution_handler/execution_handler.py
@@ -81,11 +81,15 @@ class IBSimulatedExecutionHandler(ExecutionHandler):
             quantity = event.quantity
 
             # Obtain the fill price
-            bid, ask = self.price_handler.get_best_bid_ask(ticker)
-            if event.action == "BOT":
-                fill_price = Decimal(str(ask))
+            if self.price_handler.type == "TICK_HANDLER":
+                bid, ask = self.price_handler.get_best_bid_ask(ticker)
+                if event.action == "BOT":
+                    fill_price = Decimal(str(ask))
+                else:
+                    fill_price = Decimal(str(bid))
             else:
-                fill_price = Decimal(str(bid))
+                close_price = self.price_handler.get_last_close(ticker)
+                fill_price = Decimal(str(close_price))
 
             # Set a dummy exchange and calculate trade commission
             exchange = "ARCA"

--- a/portfolio/portfolio.py
+++ b/portfolio/portfolio.py
@@ -40,7 +40,12 @@ class Portfolio(object):
         """
         for ticker in self.positions:
             pt = self.positions[ticker]
-            bid, ask = self.price_handler.get_best_bid_ask(ticker)
+            if self.price_handler.type == "TICK_HANDLER":
+                bid, ask = self.price_handler.get_best_bid_ask(ticker)
+            else:
+                close_price = self.price_handler.get_last_close(ticker)
+                bid = close_price
+                ask = close_price
             pt.update_market_value(bid, ask)
             self.unrealised_pnl += pt.unrealised_pnl
             self.realised_pnl += pt.realised_pnl
@@ -66,7 +71,12 @@ class Portfolio(object):
         """
         self._reset_values()
         if ticker not in self.positions:
-            bid, ask = self.price_handler.get_best_bid_ask(ticker)
+            if self.price_handler.type == "TICK_HANDLER":
+                bid, ask = self.price_handler.get_best_bid_ask(ticker)
+            else:
+                close_price = self.price_handler.get_last_close(ticker)
+                bid = close_price
+                ask = close_price
             position = Position(
                 action, ticker, quantity,
                 price, commission, bid, ask
@@ -97,7 +107,12 @@ class Portfolio(object):
             self.positions[ticker].transact_shares(
                 action, quantity, price, commission
             )
-            bid, ask = self.price_handler.get_best_bid_ask(ticker)
+            if self.price_handler.type == "TICK_HANDLER":
+                bid, ask = self.price_handler.get_best_bid_ask(ticker)
+            else:
+                close_price = self.price_handler.get_last_close(ticker)
+                bid = close_price
+                ask = close_price
             self.positions[ticker].update_market_value(bid, ask)
             self._update_portfolio()
         else:

--- a/portfolio/portfolio_test.py
+++ b/portfolio/portfolio_test.py
@@ -6,7 +6,7 @@ from qstrader.portfolio.portfolio import Portfolio
 
 class PriceHandlerMock(object):
     def __init__(self):
-        pass
+        self.type = "TICK_HANDLER"
 
     def get_best_bid_ask(self, ticker):
         prices = {

--- a/portfolio_handler/portfolio_handler_test.py
+++ b/portfolio_handler/portfolio_handler_test.py
@@ -9,7 +9,7 @@ from qstrader.portfolio_handler.portfolio_handler import PortfolioHandler
 
 class PriceHandlerMock(object):
     def __init__(self):
-        pass
+        self.type = "TICK_HANDLER"
 
     def get_best_bid_ask(self, ticker):
         prices = {

--- a/price_handler/yahoo_price_handler.py
+++ b/price_handler/yahoo_price_handler.py
@@ -1,54 +1,27 @@
-from __future__ import print_function
-
 import datetime
 from decimal import Decimal, getcontext, ROUND_HALF_DOWN
 import os, os.path
 
 import pandas as pd
 
-from qstrader.event.event import TickEvent
+from qstrader.event.event import BarEvent
+from qstrader.price_handler.price_handler import PriceHandler
 
 
-class PriceHandler(object):
+class YahooDailyBarPriceHandler(PriceHandler):
     """
-    PriceHandler is a base class providing an interface for
-    all subsequent (inherited) data handlers (both live and historic).
-
-    The goal of a (derived) PriceHandler object is to output a set of
-    TickEvents or BarEvents for each financial instrument and place
-    them into an event queue.
-
-    This will replicate how a live strategy would function as current
-    tick/bar data would be streamed via a brokerage. Thus a historic and live
-    system will be treated identically by the rest of the QSTrader suite.
-    """
-    def unsubscribe_ticker(self, ticker):
-        """
-        Unsubscribes the price handler from a current ticker symbol.
-        """
-        try:
-            self.tickers.pop(ticker, None)
-            self.tickers_data.pop(ticker, None)
-        except KeyError:
-            print(
-                "Could not unsubscribe ticker %s " \
-                "as it was never subscribed." % ticker
-            )
-
-
-class HistoricCSVPriceHandler(PriceHandler):
-    """
-    HistoricCSVPriceHandler is designed to read CSV files of
-    tick data for each requested financial instrument and 
-    stream those to the provided events queue as TickEvents.
+    YahooDailyBarPriceHandler is designed to read CSV files of
+    Yahoo Finance daily Open-High-Low-Close-Volume (OHLCV) data
+    for each requested financial instrument and stream those to 
+    the provided events queue as BarEvents.
     """
     def __init__(self, csv_dir, events_queue, init_tickers=None):
         """
         Takes the CSV directory, the events queue and a possible
-        list of initial ticker symbols, then creates an (optional)
+        list of initial ticker symbols then creates an (optional)
         list of ticker subscriptions and associated prices.
         """
-        self.type = "TICK_HANDLER"
+        self.type = "BAR_HANDLER"
         self.csv_dir = csv_dir
         self.events_queue = events_queue
         self.continue_backtest = True
@@ -57,7 +30,7 @@ class HistoricCSVPriceHandler(PriceHandler):
         if init_tickers is not None:
             for ticker in init_tickers:
                 self.subscribe_ticker(ticker)
-        self.tick_stream = self._merge_sort_ticker_data()
+        self.bar_stream = self._merge_sort_ticker_data()
 
     def _open_ticker_price_csv(self, ticker):
         """
@@ -68,9 +41,12 @@ class HistoricCSVPriceHandler(PriceHandler):
         ticker_path = os.path.join(self.csv_dir, "%s.csv" % ticker)
         self.tickers_data[ticker] = pd.io.parsers.read_csv(
             ticker_path, header=0, parse_dates=True, 
-            dayfirst=True, index_col=1,
-            names=("Ticker", "Time", "Bid", "Ask")
+            index_col=0, names=(
+                "Date", "Open", "High", "Low", 
+                "Close", "Volume", "Adj Close"
+            )
         )
+        self.tickers_data[ticker]["Ticker"] = ticker
 
     def _merge_sort_ticker_data(self):
         """
@@ -95,8 +71,12 @@ class HistoricCSVPriceHandler(PriceHandler):
                 dft = self.tickers_data[ticker]
                 row0 = dft.iloc[0]
                 ticker_prices = {
-                    "bid": Decimal(str(row0["Bid"])), 
-                    "ask": Decimal(str(row0["Ask"])), 
+                    "close": Decimal(
+                        str(row0["Close"])
+                    ).quantize(Decimal("0.00001")), 
+                    "adj_close": Decimal(
+                        str(row0["Adj Close"])
+                    ).quantize(Decimal("0.00001")), 
                     "timestamp": dft.index[0]
                 }
                 self.tickers[ticker] = ticker_prices
@@ -111,45 +91,51 @@ class HistoricCSVPriceHandler(PriceHandler):
                 "as is already subscribed." % ticker
             )
 
-    def get_best_bid_ask(self, ticker):
+    def get_last_close(self, ticker):
         """
-        Returns the most recent bid/ask price for a ticker.
+        Returns the most recent actual (unadjusted) closing price.
         """
         if ticker in self.tickers:
-            bid = self.tickers[ticker]["bid"]
-            ask = self.tickers[ticker]["ask"]
-            return bid, ask
+            close_price = self.tickers[ticker]["close"]
+            return close_price
         else:
             print(
-                "Bid/ask values for ticker %s are not " \
-                "available from the PriceHandler."
+                "Close price for ticker %s is not " \
+                "available from the YahooDailyBarPriceHandler."
             )
-            return None, None
+            return None
 
-    def stream_next_tick(self):
+    def stream_next_bar(self):
         """
-        Place the next TickEvent onto the event queue.
+        Place the next BarEvent onto the event queue.
         """
         try:
-            index, row = next(self.tick_stream)
+            index, row = next(self.bar_stream)
         except StopIteration:
             self.continue_backtest = False
             return
         
+        # Obtain all elements of the bar from the dataframe
         getcontext().rounding = ROUND_HALF_DOWN
         ticker = row["Ticker"]
-        bid = Decimal(str(row["Bid"])).quantize(
-            Decimal("0.00001")
-        )
-        ask = Decimal(str(row["Ask"])).quantize(
-            Decimal("0.00001")
-        )
+        open_price = Decimal(str(row["Open"])).quantize(Decimal("0.00001"))
+        high_price = Decimal(str(row["High"])).quantize(Decimal("0.00001"))
+        low_price = Decimal(str(row["Low"])).quantize(Decimal("0.00001"))
+        close_price = Decimal(str(row["Close"])).quantize(Decimal("0.00001"))
+        adj_close_price = Decimal(str(row["Adj Close"])).quantize(Decimal("0.00001"))
+        volume = int(row["Volume"])
 
-        # Create decimalised prices for traded pair
-        self.tickers[ticker]["bid"] = bid
-        self.tickers[ticker]["ask"] = ask
+        # Create decimalised prices for 
+        # closing price and adjusted closing price
+        self.tickers[ticker]["close"] = close_price
+        self.tickers[ticker]["adj_close"] = adj_close_price
         self.tickers[ticker]["timestamp"] = index
 
         # Create the tick event for the queue
-        tev = TickEvent(ticker, index, bid, ask)
-        self.events_queue.put(tev)
+        period = 86400  # Seconds in a day
+        bev = BarEvent(
+            ticker, index, period, open_price,
+            high_price, low_price, close_price,
+            volume, adj_close_price
+        )
+        self.events_queue.put(bev)

--- a/strategy/moving_average_cross_strategy.py
+++ b/strategy/moving_average_cross_strategy.py
@@ -1,0 +1,56 @@
+from collections import deque
+
+import numpy as np
+
+from qstrader.event.event import SignalEvent
+from qstrader.strategy.strategy import Strategy
+
+
+class MovingAverageCrossStrategy(Strategy):
+    """    
+    Requires:
+    tickers - The list of ticker symbols
+    events_queue - A handle to the system events queue
+    short_window - Lookback period for short moving average
+    long_window - Lookback period for long moving average
+    """
+    def __init__(
+        self, tickers, events_queue, 
+        short_window=100, long_window=400
+    ):
+        self.tickers = tickers
+        self.events_queue = events_queue
+        self.short_window = short_window
+        self.long_window = long_window
+        self.bars = 0
+        self.invested = False
+        self.sw_bars = deque(maxlen=self.short_window)
+        self.lw_bars = deque(maxlen=self.long_window)
+
+    def calculate_signals(self, event):
+        # TODO: Only applies SMA to first ticker
+        ticker = self.tickers[0]
+        if event.type == "BAR" and event.ticker == ticker:
+            # Add latest adjusted closing price to the
+            # short and long window bars
+            self.lw_bars.append(event.adj_close_price)
+            if self.bars > self.long_window - self.short_window:
+                self.sw_bars.append(event.adj_close_price)
+
+            # Enough bars are present for trading
+            if self.bars > self.long_window:
+                # Calculate the simple moving averages
+                short_sma = np.mean(self.sw_bars)
+                long_sma = np.mean(self.lw_bars)
+                # Trading signals based on moving average cross
+                if short_sma > long_sma and not self.invested:
+                    print("LONG: %s" % event.time)
+                    signal = SignalEvent(ticker, "BOT")
+                    self.events_queue.put(signal)
+                    self.invested = True
+                elif short_sma < long_sma and self.invested:
+                    print("SHORT: %s" % event.time)
+                    signal = SignalEvent(ticker, "SLD")
+                    self.events_queue.put(signal)
+                    self.invested = False
+            self.bars += 1

--- a/strategy/strategy.py
+++ b/strategy/strategy.py
@@ -59,7 +59,7 @@ class TestStrategy(Strategy):
 class BuyAndHoldStrategy(Strategy):
     """
     A testing strategy that simply purchases (longs) a set of
-    assets upon first receipt of the relevant tick event and 
+    assets upon first receipt of the relevant bar event and 
     then holds until the completion of a backtest.
     """
     def __init__(self, tickers, events_queue):
@@ -70,7 +70,7 @@ class BuyAndHoldStrategy(Strategy):
 
     def calculate_signals(self, event):
         ticker = self.tickers[0]
-        if event.type == "TICK" and event.ticker == ticker:
+        if event.type == "BAR" and event.ticker == ticker:
             if not self.invested and self.ticks == 0:
                 signal = SignalEvent(ticker, "BOT")
                 self.events_queue.put(signal)


### PR DESCRIPTION
* Adds the BarEvent object. [No unit tests yet]
* Modifies the remainder of the QSTrader codebase to work with both BarEvent and TickEvent objects, depending upon the PriceHandler selected [No additional unit tests added]
* Adds a basic MovingAverageCrossoverStrategy object as a first non-trivial test of QSTrader backtesting behaviour [No unit tests yet]

The latter change requires a download of AAPL data from Yahoo Finance in order to function.