### PR TITLE
Configurable backtest components

### DIFF
--- a/backtest/backtest.py
+++ b/backtest/backtest.py
@@ -5,108 +5,108 @@ import os, os.path
 import pprint
 from qstrader.statistics.statistics import Statistics
 try:
-		import Queue as queue
+    import Queue as queue
 except ImportError:
-		import queue
+    import queue
 import time
 
 try:
-		from qstrader import settings
+    from qstrader import settings
 except ImportError:
-		print(
-				"Could not import settings.py. Have you copied " \
-				"settings.py.example to settings.py and configured " \
-				"your QSTrader settings?"
-		)
+    print(
+        "Could not import settings.py. Have you copied " \
+        "settings.py.example to settings.py and configured " \
+        "your QSTrader settings?"
+    )
 
 
 class Backtest(object):
-		"""
-		Enscapsulates the settings and components for 
-		carrying out an event-driven backtest.
-		"""
-		def __init__(
-				self, tickers, price_handler, 
-				strategy, portfolio_handler, 
-				execution_handler, 
-				position_sizer, risk_manager,
-				statistics,
-				equity=Decimal("100000.00"), 
-				heartbeat=0.0, max_iters=10000000000
-		):
-			"""
-			Set up the backtest variables according to 
-			what has been passed in.
-			"""
-			
-			self.tickers = tickers
-			self.price_handler = price_handler
-			self.strategy = strategy
-			self.portfolio_handler = portfolio_handler
-			self.execution_handler = execution_handler
-			self.position_sizer = position_sizer
-			self.risk_manager = risk_manager
-			self.statistics = statistics
-			self.equity = equity
-			self.heartbeat = heartbeat
-			self.max_iters = max_iters
-			self.events_queue = price_handler.events_queue
-			self.cur_time = None
+    """
+    Enscapsulates the settings and components for 
+    carrying out an event-driven backtest.
+    """
+    def __init__(
+        self, tickers, price_handler, 
+        strategy, portfolio_handler, 
+        execution_handler, 
+        position_sizer, risk_manager,
+        statistics,
+        equity=Decimal("100000.00"), 
+        heartbeat=0.0, max_iters=10000000000
+    ):
+      """
+      Set up the backtest variables according to 
+      what has been passed in.
+      """
+      
+      self.tickers = tickers
+      self.price_handler = price_handler
+      self.strategy = strategy
+      self.portfolio_handler = portfolio_handler
+      self.execution_handler = execution_handler
+      self.position_sizer = position_sizer
+      self.risk_manager = risk_manager
+      self.statistics = statistics
+      self.equity = equity
+      self.heartbeat = heartbeat
+      self.max_iters = max_iters
+      self.events_queue = price_handler.events_queue
+      self.cur_time = None
 
-		def _run_backtest(self):
-				"""
-				Carries out an infinite while loop that polls the 
-				events queue and directs each event to either the
-				strategy component of the execution handler. The
-				loop will then pause for "heartbeat" seconds and
-				continue unti the maximum number of iterations is
-				exceeded.
-				"""
-				print("Running Backtest...")
-				iters = 0
-				ticks = 0
-				bars = 0
-				while iters < self.max_iters and self.price_handler.continue_backtest:
-						try:
-								event = self.events_queue.get(False)
-						except queue.Empty:
-								if self.price_handler.type == "TICK_HANDLER":
-										self.price_handler.stream_next_tick()
-								else:
-										self.price_handler.stream_next_bar()
-						else:
-								if event is not None:
-										if event.type == 'TICK':
-												self.cur_time = event.time
-												print("Tick %s, at %s" % (ticks, self.cur_time))
-												self.strategy.calculate_signals(event)
-												self.portfolio_handler.portfolio._reset_values()
-												self.portfolio_handler.update_portfolio_value()
-												self.statistics.update(event.time)
-												ticks += 1
-										elif event.type == 'BAR':
-												self.cur_time = event.time
-												print("Bar %s, at %s" % (bars, self.cur_time))
-												self.strategy.calculate_signals(event)
-												self.portfolio_handler.portfolio._reset_values()
-												self.portfolio_handler.update_portfolio_value()
-												self.statistics.update(event.time)
-												bars += 1
-										elif event.type == 'SIGNAL':
-												self.portfolio_handler.on_signal(event)
-										elif event.type == 'ORDER':
-												self.execution_handler.execute_order(event)
-										elif event.type == 'FILL':
-												self.portfolio_handler.on_fill(event)
-						time.sleep(self.heartbeat)
-						iters += 1
+    def _run_backtest(self):
+        """
+        Carries out an infinite while loop that polls the 
+        events queue and directs each event to either the
+        strategy component of the execution handler. The
+        loop will then pause for "heartbeat" seconds and
+        continue unti the maximum number of iterations is
+        exceeded.
+        """
+        print("Running Backtest...")
+        iters = 0
+        ticks = 0
+        bars = 0
+        while iters < self.max_iters and self.price_handler.continue_backtest:
+            try:
+                event = self.events_queue.get(False)
+            except queue.Empty:
+                if self.price_handler.type == "TICK_HANDLER":
+                    self.price_handler.stream_next_tick()
+                else:
+                    self.price_handler.stream_next_bar()
+            else:
+                if event is not None:
+                    if event.type == 'TICK':
+                        self.cur_time = event.time
+                        print("Tick %s, at %s" % (ticks, self.cur_time))
+                        self.strategy.calculate_signals(event)
+                        self.portfolio_handler.portfolio._reset_values()
+                        self.portfolio_handler.update_portfolio_value()
+                        self.statistics.update(event.time)
+                        ticks += 1
+                    elif event.type == 'BAR':
+                        self.cur_time = event.time
+                        print("Bar %s, at %s" % (bars, self.cur_time))
+                        self.strategy.calculate_signals(event)
+                        self.portfolio_handler.portfolio._reset_values()
+                        self.portfolio_handler.update_portfolio_value()
+                        self.statistics.update(event.time)
+                        bars += 1
+                    elif event.type == 'SIGNAL':
+                        self.portfolio_handler.on_signal(event)
+                    elif event.type == 'ORDER':
+                        self.execution_handler.execute_order(event)
+                    elif event.type == 'FILL':
+                        self.portfolio_handler.on_fill(event)
+            time.sleep(self.heartbeat)
+            iters += 1
 
 
-		def simulate_trading(self):
-				"""
-				Simulates the backtest and outputs portfolio performance.
-				"""
-				self._run_backtest()
-				print("Backtest complete.")
-				self.statistics.get_results()
-				self.statistics.plot_results()
+    def simulate_trading(self):
+        """
+        Simulates the backtest and outputs portfolio performance.
+        """
+        self._run_backtest()
+        print("Backtest complete.")
+        self.statistics.get_results()
+        self.statistics.plot_results()

--- a/backtest/backtest.py
+++ b/backtest/backtest.py
@@ -5,135 +5,108 @@ import os, os.path
 import pprint
 from qstrader.statistics.statistics import Statistics
 try:
-    import Queue as queue
+		import Queue as queue
 except ImportError:
-    import queue
+		import queue
 import time
 
 try:
-    from qstrader import settings
+		from qstrader import settings
 except ImportError:
-    print(
-        "Could not import settings.py. Have you copied " \
-        "settings.py.example to settings.py and configured " \
-        "your QSTrader settings?"
-    )
+		print(
+				"Could not import settings.py. Have you copied " \
+				"settings.py.example to settings.py and configured " \
+				"your QSTrader settings?"
+		)
 
 
 class Backtest(object):
-    """
-    Enscapsulates the settings and components for 
-    carrying out an event-driven backtest.
-    """
-    def __init__(
-        self, tickers, price_handler, 
-        strategy, portfolio_handler, 
-        execution_handler, 
-        position_sizer, risk_manager,
-        equity=Decimal("100000.00"), 
-        heartbeat=0.0, max_iters=10000000000
-    ):
-        """
-        Initialises the backtest.
-        """
-        self.tickers = tickers
-        self.events_queue = queue.Queue()
-        self.csv_dir = settings.CSV_DATA_DIR
-        self.output_dir = settings.OUTPUT_DIR
-        self.equity_file = os.path.join(
-            self.output_dir, "equity.csv"
-        )
+		"""
+		Enscapsulates the settings and components for 
+		carrying out an event-driven backtest.
+		"""
+		def __init__(
+				self, tickers, price_handler, 
+				strategy, portfolio_handler, 
+				execution_handler, 
+				position_sizer, risk_manager,
+				statistics,
+				equity=Decimal("100000.00"), 
+				heartbeat=0.0, max_iters=10000000000
+		):
+			"""
+			Set up the backtest variables according to 
+			what has been passed in.
+			"""
+			
+			self.tickers = tickers
+			self.price_handler = price_handler
+			self.strategy = strategy
+			self.portfolio_handler = portfolio_handler
+			self.execution_handler = execution_handler
+			self.position_sizer = position_sizer
+			self.risk_manager = risk_manager
+			self.statistics = statistics
+			self.equity = equity
+			self.heartbeat = heartbeat
+			self.max_iters = max_iters
+			self.events_queue = price_handler.events_queue
+			self.cur_time = None
 
-        self.price_handler = price_handler(
-            self.csv_dir, self.events_queue, 
-            init_tickers=self.tickers
-        )
-        self.strategy = strategy(
-            self.tickers, self.events_queue
-        )
-        self.equity = equity
-        self.heartbeat = heartbeat
-        self.max_iters = max_iters
-
-        self.position_sizer = position_sizer()
-        self.risk_manager = risk_manager()
-
-        self.portfolio_handler = portfolio_handler(
-            self.equity, self.events_queue, self.price_handler,
-            self.position_sizer, self.risk_manager
-        )
-        self.execution_handler = execution_handler(
-            self.events_queue, self.price_handler
-        )
-
-        self.cur_time = None
-
-        # Open the equity file and clear it prior to append
-        open(self.equity_file, 'w').close()
-
-    def _append_equity_state(self):
-        cur_port_state = self.portfolio_handler.portfolio.create_portfolio_state_dict()
-        with open(self.equity_file, "a") as eqfile:
-            eqfile.write(
-                "%s,%s\n" % (
-                    self.cur_time, cur_port_state["equity"]
-                )
-            )
-
-    def _run_backtest(self):
-        """
-        Carries out an infinite while loop that polls the 
-        events queue and directs each event to either the
-        strategy component of the execution handler. The
-        loop will then pause for "heartbeat" seconds and
-        continue unti the maximum number of iterations is
-        exceeded.
-        """
-        print("Running Backtest...")
-        iters = 0
-        ticks = 0
-        bars = 0
-        while iters < self.max_iters and self.price_handler.continue_backtest:
-            try:
-                event = self.events_queue.get(False)
-            except queue.Empty:
-                if self.price_handler.type == "TICK_HANDLER":
-                    self.price_handler.stream_next_tick()
-                else:
-                    self.price_handler.stream_next_bar()
-            else:
-                if event is not None:
-                    if event.type == 'TICK':
-                        self.cur_time = event.time
-                        print("Tick %s, at %s" % (ticks, self.cur_time))
-                        self._append_equity_state()
-                        self.strategy.calculate_signals(event)
-                        self.portfolio_handler.update_portfolio_value()
-                        ticks += 1
-                    elif event.type == 'BAR':
-                        self.cur_time = event.time
-                        print("Bar %s, at %s" % (bars, self.cur_time))
-                        self._append_equity_state()
-                        self.strategy.calculate_signals(event)
-                        self.portfolio_handler.update_portfolio_value()
-                        bars += 1
-                    elif event.type == 'SIGNAL':
-                        self.portfolio_handler.on_signal(event)
-                    elif event.type == 'ORDER':
-                        self.execution_handler.execute_order(event)
-                    elif event.type == 'FILL':
-                        self.portfolio_handler.on_fill(event)
-            time.sleep(self.heartbeat)
-            iters += 1
+		def _run_backtest(self):
+				"""
+				Carries out an infinite while loop that polls the 
+				events queue and directs each event to either the
+				strategy component of the execution handler. The
+				loop will then pause for "heartbeat" seconds and
+				continue unti the maximum number of iterations is
+				exceeded.
+				"""
+				print("Running Backtest...")
+				iters = 0
+				ticks = 0
+				bars = 0
+				while iters < self.max_iters and self.price_handler.continue_backtest:
+						try:
+								event = self.events_queue.get(False)
+						except queue.Empty:
+								if self.price_handler.type == "TICK_HANDLER":
+										self.price_handler.stream_next_tick()
+								else:
+										self.price_handler.stream_next_bar()
+						else:
+								if event is not None:
+										if event.type == 'TICK':
+												self.cur_time = event.time
+												print("Tick %s, at %s" % (ticks, self.cur_time))
+												self.strategy.calculate_signals(event)
+												self.portfolio_handler.portfolio._reset_values()
+												self.portfolio_handler.update_portfolio_value()
+												self.statistics.update(event.time)
+												ticks += 1
+										elif event.type == 'BAR':
+												self.cur_time = event.time
+												print("Bar %s, at %s" % (bars, self.cur_time))
+												self.strategy.calculate_signals(event)
+												self.portfolio_handler.portfolio._reset_values()
+												self.portfolio_handler.update_portfolio_value()
+												self.statistics.update(event.time)
+												bars += 1
+										elif event.type == 'SIGNAL':
+												self.portfolio_handler.on_signal(event)
+										elif event.type == 'ORDER':
+												self.execution_handler.execute_order(event)
+										elif event.type == 'FILL':
+												self.portfolio_handler.on_fill(event)
+						time.sleep(self.heartbeat)
+						iters += 1
 
 
-    def simulate_trading(self):
-        """
-        Simulates the backtest and outputs portfolio performance.
-        """
-        self._run_backtest()
-        print("Backtest complete.")
-        statistics = Statistics()
-        statistics.generate_results()
-        statistics.plot_results()
-        
+		def simulate_trading(self):
+				"""
+				Simulates the backtest and outputs portfolio performance.
+				"""
+				self._run_backtest()
+				print("Backtest complete.")
+				self.statistics.get_results()
+				self.statistics.plot_results()

--- a/examples/test_mac_backtest.py
+++ b/examples/test_mac_backtest.py
@@ -3,28 +3,27 @@ from decimal import Decimal
 from qstrader.backtest.backtest import Backtest
 from qstrader.execution_handler.execution_handler import IBSimulatedExecutionHandler
 from qstrader.portfolio_handler.portfolio_handler import PortfolioHandler
-from qstrader.position_sizer.balanced_position_sizer import BalancedPositionSizer
+from qstrader.position_sizer.position_sizer import TestPositionSizer
 from qstrader.price_handler.yahoo_price_handler import YahooDailyBarPriceHandler
-from qstrader.risk_manager.balanced_risk_manager import BalancedRiskManager
+from qstrader.risk_manager.risk_manager import TestRiskManager
 from qstrader.statistics.statistics import SimpleStatistics
 from qstrader import settings
 from qstrader.strategy.moving_average_cross_strategy import MovingAverageCrossStrategy
 try:
-		import Queue as queue
+        import Queue as queue
 except ImportError:
-		import queue
+        import queue
 
 
 if __name__ == "__main__":
     tickers = ["AAPL"]
 
-	# Set up variables needed for backtest
+    # Set up variables needed for backtest
     events_queue = queue.Queue()
     csv_dir = settings.CSV_DATA_DIR
     initial_equity = Decimal("500000.00")
     heartbeat = 0.0
     max_iters = 10000000000
-    NUM_STOCKS = 1
 
     # Use Yahoo Daily Price Handler
     price_handler = YahooDailyBarPriceHandler(
@@ -34,11 +33,11 @@ if __name__ == "__main__":
     # Use the MAC Strategy
     strategy = MovingAverageCrossStrategy( tickers, events_queue )
 
-    # Use an example Position Sizer, 1 stock
-    position_sizer = BalancedPositionSizer(NUM_STOCKS)
+    # Use an example Position Sizer, 
+    position_sizer = TestPositionSizer()
 
-    # Use a balanced Risk Manager, 1 stock
-    risk_manager = BalancedRiskManager(NUM_STOCKS)
+    # Use an example Risk Manager, 
+    risk_manager = TestRiskManager()
 
     # Use the default Portfolio Handler
     portfolio_handler = PortfolioHandler(

--- a/examples/test_mac_backtest.py
+++ b/examples/test_mac_backtest.py
@@ -3,21 +3,64 @@ from decimal import Decimal
 from qstrader.backtest.backtest import Backtest
 from qstrader.execution_handler.execution_handler import IBSimulatedExecutionHandler
 from qstrader.portfolio_handler.portfolio_handler import PortfolioHandler
-from qstrader.position_sizer.position_sizer import TestPositionSizer
+from qstrader.position_sizer.balanced_position_sizer import BalancedPositionSizer
 from qstrader.price_handler.yahoo_price_handler import YahooDailyBarPriceHandler
-from qstrader.risk_manager.risk_manager import TestRiskManager
+from qstrader.risk_manager.balanced_risk_manager import BalancedRiskManager
+from qstrader.statistics.statistics import SimpleStatistics
 from qstrader import settings
 from qstrader.strategy.moving_average_cross_strategy import MovingAverageCrossStrategy
+try:
+		import Queue as queue
+except ImportError:
+		import queue
 
 
 if __name__ == "__main__":
     tickers = ["AAPL"]
 
+	# Set up variables needed for backtest
+    events_queue = queue.Queue()
+    csv_dir = settings.CSV_DATA_DIR
+    initial_equity = Decimal("500000.00")
+    heartbeat = 0.0
+    max_iters = 10000000000
+    NUM_STOCKS = 1
+
+    # Use Yahoo Daily Price Handler
+    price_handler = YahooDailyBarPriceHandler(
+        csv_dir, events_queue, tickers
+    )
+
+    # Use the MAC Strategy
+    strategy = MovingAverageCrossStrategy( tickers, events_queue )
+
+    # Use an example Position Sizer, 1 stock
+    position_sizer = BalancedPositionSizer(NUM_STOCKS)
+
+    # Use a balanced Risk Manager, 1 stock
+    risk_manager = BalancedRiskManager(NUM_STOCKS)
+
+    # Use the default Portfolio Handler
+    portfolio_handler = PortfolioHandler(
+        initial_equity, events_queue, price_handler,
+        position_sizer, risk_manager
+    )
+    
+    # Use a simulated IB Execution Handler
+    execution_handler = IBSimulatedExecutionHandler(
+        events_queue, price_handler
+    )
+
+    # Use the default Statistics
+    statistics = SimpleStatistics(portfolio_handler)
+
+    # Set up the backtest
     backtest = Backtest(
-        tickers, YahooDailyBarPriceHandler, 
-        MovingAverageCrossStrategy, PortfolioHandler, 
-        IBSimulatedExecutionHandler,
-        TestPositionSizer, TestRiskManager, 
-        equity=Decimal("500000.00")
+        tickers, price_handler, 
+        strategy, portfolio_handler, 
+        execution_handler,
+        position_sizer, risk_manager, 
+        statistics,
+        initial_equity
     )
     backtest.simulate_trading()

--- a/examples/test_sp500tr_buy_and_hold_backtest.py
+++ b/examples/test_sp500tr_buy_and_hold_backtest.py
@@ -6,18 +6,59 @@ from qstrader.portfolio_handler.portfolio_handler import PortfolioHandler
 from qstrader.position_sizer.position_sizer import TestPositionSizer
 from qstrader.price_handler.yahoo_price_handler import YahooDailyBarPriceHandler
 from qstrader.risk_manager.risk_manager import TestRiskManager
+from qstrader.statistics.statistics import SimpleStatistics
 from qstrader import settings
 from qstrader.strategy.strategy import BuyAndHoldStrategy
-
+try:
+	import Queue as queue
+except ImportError:
+	import queue
 
 if __name__ == "__main__":
     tickers = ["SP500TR"]
 
+    # Set up variables needed for backtest
+    events_queue = queue.Queue()
+    csv_dir = settings.CSV_DATA_DIR
+    initial_equity = Decimal("500000.00")
+    heartbeat = 0.0
+    max_iters = 10000000000
+
+    # Use Yahoo Daily Price Handler
+    price_handler = YahooDailyBarPriceHandler(
+        csv_dir, events_queue, tickers
+    )
+
+    # Use the Buy and Hold Strategy
+    strategy = BuyAndHoldStrategy( tickers, events_queue )
+
+    # Use an example Position Sizer
+    position_sizer = TestPositionSizer()
+
+    # Use an example Risk Manager
+    risk_manager = TestRiskManager()
+
+    # Use the default Portfolio Handler
+    portfolio_handler = PortfolioHandler(
+        initial_equity, events_queue, price_handler,
+        position_sizer, risk_manager
+    )
+    
+    # Use a simulated IB Execution Handler
+    execution_handler = IBSimulatedExecutionHandler(
+        events_queue, price_handler
+    )
+
+    # Use the default Statistics
+    statistics = SimpleStatistics(portfolio_handler)
+
+    # Set up the backtest
     backtest = Backtest(
-        tickers, YahooDailyBarPriceHandler, 
-        BuyAndHoldStrategy, PortfolioHandler, 
-        IBSimulatedExecutionHandler,
-        TestPositionSizer, TestRiskManager, 
-        equity=Decimal("500000.00")
+        tickers, price_handler, 
+        strategy, portfolio_handler, 
+        execution_handler,
+        position_sizer, risk_manager, 
+        statistics,
+        initial_equity
     )
     backtest.simulate_trading()

--- a/examples/test_strategy_backtest.py
+++ b/examples/test_strategy_backtest.py
@@ -6,18 +6,59 @@ from qstrader.portfolio_handler.portfolio_handler import PortfolioHandler
 from qstrader.position_sizer.position_sizer import TestPositionSizer
 from qstrader.price_handler.price_handler import HistoricCSVPriceHandler
 from qstrader.risk_manager.risk_manager import TestRiskManager
+from qstrader.statistics.statistics import SimpleStatistics
 from qstrader import settings
 from qstrader.strategy.strategy import TestStrategy
-
+try:
+		import Queue as queue
+except ImportError:
+		import queue
 
 if __name__ == "__main__":
     tickers = ["GOOG"]
 
+    # Set up variables needed for backtest
+    events_queue = queue.Queue()
+    csv_dir = settings.CSV_DATA_DIR
+    initial_equity = Decimal("500000.00")
+    heartbeat = 0.0
+    max_iters = 10000000000
+
+    # Use Historic CSV Price Handler
+    price_handler = HistoricCSVPriceHandler(
+        csv_dir, events_queue, tickers
+    )
+
+    # Use the Test Strategy
+    strategy = TestStrategy( tickers, events_queue )
+
+    # Use an example Position Sizer
+    position_sizer = TestPositionSizer()
+
+    # Use an example Risk Manager
+    risk_manager = TestRiskManager()
+
+    # Use the default Portfolio Handler
+    portfolio_handler = PortfolioHandler(
+        initial_equity, events_queue, price_handler,
+        position_sizer, risk_manager
+    )
+    
+    # Use a simulated IB Execution Handler
+    execution_handler = IBSimulatedExecutionHandler(
+        events_queue, price_handler
+    )
+
+    # Use the default Statistics
+    statistics = SimpleStatistics(portfolio_handler)
+
+    # Set up the backtest
     backtest = Backtest(
-        tickers, HistoricCSVPriceHandler, 
-        TestStrategy, PortfolioHandler, 
-        IBSimulatedExecutionHandler,
-        TestPositionSizer, TestRiskManager, 
-        equity=Decimal("500000.00")
+        tickers, price_handler, 
+        strategy, portfolio_handler, 
+        execution_handler,
+        position_sizer, risk_manager, 
+        statistics,
+        initial_equity
     )
     backtest.simulate_trading()


### PR DESCRIPTION
While this does make "working" files more complex, it allows a lot more component configuration in a nice way. A few examples;

1) Changing the sharpe ratio benchmark would be done in the user's working file with a call like `statistics.set_benchmark_return(0.01)`

2) Setting the date window for a backtest would look like:

        begin = time.mktime(time.strptime('2011/01/01', "%Y/%m/%d"))
        end = time.mktime(time.strptime('2016/03/01', "%Y/%m/%d"))
        price_handler.set_date_window(begin, end)

3) Configuring the Moving Average windows would look like:
`strategy.set_windows(100, 400)`



Without this or something similar, the above three examples would be impossible to do without messing around with the 'core' files. I feel like it's a lot more manageable to make those small changes in a user's working files -- I've found it to be very useful when building strategies or researching ideas.