### PR TITLE
Save results

### DIFF
--- a/examples/buy_and_hold_backtest.py
+++ b/examples/buy_and_hold_backtest.py
@@ -16,7 +16,7 @@ from qstrader.statistics.simple import SimpleStatistics
 from qstrader.trading_session.backtest import Backtest
 
 
-def run(config, testing, tickers):
+def run(config, testing, tickers, filename):
 
     # Set up variables needed for backtest
     events_queue = queue.Queue()
@@ -55,7 +55,7 @@ def run(config, testing, tickers):
     )
 
     # Use the default Statistics
-    statistics = SimpleStatistics(portfolio_handler)
+    statistics = SimpleStatistics(config, portfolio_handler)
 
     # Set up the backtest
     backtest = Backtest(
@@ -67,6 +67,7 @@ def run(config, testing, tickers):
         initial_equity
     )
     results = backtest.simulate_trading(testing=testing)
+    statistics.save(filename)
     return results
 
 
@@ -74,10 +75,11 @@ def run(config, testing, tickers):
 @click.option('--config', default=settings.DEFAULT_CONFIG_FILENAME, help='Config filename')
 @click.option('--testing/--no-testing', default=False, help='Enable testing mode')
 @click.option('--tickers', default='SP500TR', help='Tickers (use comma)')
-def main(config, testing, tickers):
+@click.option('--filename', default='', help='Pickle (.pkl) statistics filename')
+def main(config, testing, tickers, filename):
     tickers = tickers.split(",")
     config = settings.from_file(config, testing)
-    run(config, testing, tickers)
+    run(config, testing, tickers, filename)
 
 
 if __name__ == "__main__":

--- a/examples/mac_backtest.py
+++ b/examples/mac_backtest.py
@@ -15,7 +15,7 @@ from qstrader.statistics.simple import SimpleStatistics
 from qstrader.trading_session.backtest import Backtest
 
 
-def run(config, testing, tickers):
+def run(config, testing, tickers, filename):
 
     # Set up variables needed for backtest
     events_queue = queue.Queue()
@@ -53,7 +53,7 @@ def run(config, testing, tickers):
     )
 
     # Use the default Statistics
-    statistics = SimpleStatistics(portfolio_handler)
+    statistics = SimpleStatistics(config, portfolio_handler)
 
     # Set up the backtest
     backtest = Backtest(
@@ -65,6 +65,7 @@ def run(config, testing, tickers):
         initial_equity
     )
     results = backtest.simulate_trading(testing=testing)
+    statistics.save(filename)
     return results
 
 
@@ -72,10 +73,11 @@ def run(config, testing, tickers):
 @click.option('--config', default=settings.DEFAULT_CONFIG_FILENAME, help='Config filename')
 @click.option('--testing/--no-testing', default=False, help='Enable testing mode')
 @click.option('--tickers', default='SP500TR', help='Tickers (use comma)')
-def main(config, testing, tickers):
+@click.option('--filename', default='', help='Pickle (.pkl) statistics filename')
+def main(config, testing, tickers, filename):
     tickers = tickers.split(",")
     config = settings.from_file(config, testing)
-    run(config, testing, tickers)
+    run(config, testing, tickers, filename)
 
 if __name__ == "__main__":
     main()

--- a/examples/strategy_backtest.py
+++ b/examples/strategy_backtest.py
@@ -15,7 +15,7 @@ from qstrader.statistics.simple import SimpleStatistics
 from qstrader.trading_session.backtest import Backtest
 
 
-def run(config, testing, tickers):
+def run(config, testing, tickers, filename):
 
     # Set up variables needed for backtest
     events_queue = queue.Queue()
@@ -52,7 +52,7 @@ def run(config, testing, tickers):
         events_queue, price_handler, compliance
     )
     # Use the default Statistics
-    statistics = SimpleStatistics(portfolio_handler)
+    statistics = SimpleStatistics(config, portfolio_handler)
 
     # Set up the backtest
     backtest = Backtest(
@@ -64,6 +64,7 @@ def run(config, testing, tickers):
         initial_equity
     )
     results = backtest.simulate_trading(testing=testing)
+    statistics.save(filename)
     return results
 
 
@@ -71,10 +72,11 @@ def run(config, testing, tickers):
 @click.option('--config', default=settings.DEFAULT_CONFIG_FILENAME, help='Config filename')
 @click.option('--testing/--no-testing', default=False, help='Enable testing mode')
 @click.option('--tickers', default='GOOG', help='Tickers (use comma)')
-def main(config, testing, tickers):
+@click.option('--filename', default='', help='Pickle (.pkl) statistics filename')
+def main(config, testing, tickers, filename):
     tickers = tickers.split(",")
     config = settings.from_file(config, testing)
-    run(config, testing, tickers)
+    run(config, testing, tickers, filename)
 
 
 if __name__ == "__main__":

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -6,9 +6,11 @@ One example can be test individually using:
 $ nosetests -s -v tests/test_examples.py:TestExamples.test_strategy_backtest
 
 """
+import os
 import unittest
 
 from qstrader import settings
+from qstrader.statistics import load
 import examples.buy_and_hold_backtest
 import examples.mac_backtest
 import examples.strategy_backtest
@@ -32,7 +34,8 @@ class TestExamples(unittest.TestCase):
         Bar 1628, at 2016-06-22 00:00:00
         """
         tickers = ["SP500TR"]
-        results = examples.buy_and_hold_backtest.run(self.config, self.testing, tickers)
+        filename = os.path.join(settings.TEST.OUTPUT_DIR, "buy_and_hold_backtest.pkl")
+        results = examples.buy_and_hold_backtest.run(self.config, self.testing, tickers, filename)
         for (key, expected) in [
             ('sharpe', 0.5969),
             ('max_drawdown_pct', 5.0308),
@@ -49,13 +52,17 @@ class TestExamples(unittest.TestCase):
             self.assertAlmostEqual(float(max(values)), expected['max'])
             self.assertAlmostEqual(float(values.iloc[0]), expected['first'])
             self.assertAlmostEqual(float(values.iloc[-1]), expected['last'])
+        stats = load(filename)
+        results = stats.get_results()
+        self.assertAlmostEqual(float(results['sharpe']), 0.5969)
 
     def test_mac_backtest(self):
         """
         Test mac_backtest
         """
         tickers = ["SP500TR"]
-        results = examples.mac_backtest.run(self.config, self.testing, tickers)
+        filename = os.path.join(settings.TEST.OUTPUT_DIR, "mac_backtest.pkl")
+        results = examples.mac_backtest.run(self.config, self.testing, tickers, filename)
         self.assertAlmostEqual(float(results['sharpe']), 0.6018)
 
     def test_strategy_backtest(self):
@@ -63,5 +70,6 @@ class TestExamples(unittest.TestCase):
         Test strategy_backtest
         """
         tickers = ["GOOG"]
-        results = examples.strategy_backtest.run(self.config, self.testing, tickers)
+        filename = os.path.join(settings.TEST.OUTPUT_DIR, "strategy_backtest.pkl")
+        results = examples.strategy_backtest.run(self.config, self.testing, tickers, filename)
         self.assertAlmostEqual(float(results['sharpe']), -7.5299)

--- a/load_statistics.ipynb
+++ b/load_statistics.ipynb
@@ -1,0 +1,175 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from qstrader import settings\n",
+    "from qstrader.statistics import load"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# config = settings.TEST\n",
+    "config = settings.from_file()\n",
+    "# config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "out_dir = os.path.expanduser(config.OUTPUT_DIR)\n",
+    "stats = load(os.path.join(out_dir, \"statistics_2016-07-04_192217.pkl\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "results = stats.get_results()\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "ts = results['equity'][1:]\n",
+    "ts.index.name = 'Date'\n",
+    "ts.name='Equity'\n",
+    "ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "from pylab import rcParams\n",
+    "rcParams['figure.figsize'] = 12, 6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import mpld3\n",
+    "mpld3.enable_notebook()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "ts.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import bokeh\n",
+    "from bokeh.plotting import figure\n",
+    "from bokeh.io import output_notebook\n",
+    "from bokeh.charts import show"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "output_notebook()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from bokeh.charts import TimeSeries\n",
+    "PLOT_WIDTH, PLOT_HEIGHT = 900, 400"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "p = TimeSeries(ts, title=\"Results\", ylabel='Equity', plot_width=PLOT_WIDTH, plot_height=PLOT_HEIGHT)\n",
+    "show(p)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/load_statistics.ipynb
+++ b/load_statistics.ipynb
@@ -146,16 +146,16 @@
    },
    "outputs": [],
    "source": [
-    "p = TimeSeries(ts, title=\"Results\", ylabel='Equity', plot_width=PLOT_WIDTH, plot_height=PLOT_HEIGHT)\n",
+    "p = TimeSeries(ts, title=\"Results\", ylabel=ts.name, xlabel=ts.index.name, plot_width=PLOT_WIDTH, plot_height=PLOT_HEIGHT)\n",
     "show(p)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [Root]",
    "language": "python",
-   "name": "python3"
+   "name": "Python [Root]"
   },
   "language_info": {
    "codemirror_mode": {
@@ -167,7 +167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/qstrader/compat.py
+++ b/qstrader/compat.py
@@ -9,3 +9,8 @@ if PY2:
     import Queue as queue
 else:  # PY3
     import queue
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle

--- a/qstrader/statistics/__init__.py
+++ b/qstrader/statistics/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from .base import load

--- a/qstrader/statistics/base.py
+++ b/qstrader/statistics/base.py
@@ -1,5 +1,7 @@
 from abc import ABCMeta, abstractmethod
 
+from ..compat import pickle
+
 
 class AbstractStatistics(object):
     """
@@ -42,3 +44,20 @@ class AbstractStatistics(object):
         Plot all statistics collected up until 'now'
         """
         raise NotImplementedError("Should implement plot_results()")
+
+    @abstractmethod
+    def save(self, filename):
+        """
+        Save statistics results to filename
+        """
+        raise NotImplementedError("Should implement save()")
+
+    @classmethod
+    def load(cls, filename):
+        with open(filename, 'rb') as fd:
+            stats = pickle.load(fd)
+        return stats
+
+
+def load(filename):
+    return AbstractStatistics.load(filename)

--- a/qstrader/statistics/simple.py
+++ b/qstrader/statistics/simple.py
@@ -1,5 +1,8 @@
 from .base import AbstractStatistics
+from ..compat import pickle
 
+import datetime
+import os
 import pandas as pd
 import numpy as np
 import matplotlib
@@ -29,24 +32,24 @@ class SimpleStatistics(AbstractStatistics):
     TODO need some kind of trading-frequency parameter in setup.
     Sharpe calculations need to know if daily, hourly, minutely, etc.
     """
-    def __init__(self, portfolio_handler):
+    def __init__(self, config, portfolio_handler):
         """
         Takes in a portfolio handler.
         """
-        self.portfolio_handler = portfolio_handler
+        self.config = config
         self.drawdowns = pd.Series()
         self.equity = pd.Series()
         self.equity_returns = pd.Series()
         # Initialize in order for first-step calculations to be correct.
-        self.hwm = [float(self.portfolio_handler.portfolio.equity)]
-        self.equity.ix["0000-00-00 00:00:00"] = float(self.portfolio_handler.portfolio.equity)
+        self.hwm = [float(portfolio_handler.portfolio.equity)]
+        self.equity.ix["0000-00-00 00:00:00"] = float(portfolio_handler.portfolio.equity)
 
-    def update(self, timestamp):
+    def update(self, timestamp, portfolio_handler):
         """
         Update all statistics that must be tracked over time.
         """
         # Retrieve equity value of Portfolio
-        self.equity.ix[timestamp] = float(self.portfolio_handler.portfolio.equity)
+        self.equity.ix[timestamp] = float(portfolio_handler.portfolio.equity)
         current_index = len(self.equity) - 1
 
         # Calculate percentage return between current and previous equity value.
@@ -150,3 +153,17 @@ class SimpleStatistics(AbstractStatistics):
 
         # Plot the figure
         plt.show()
+
+    def get_filename(self, filename=""):
+        if filename == "":
+            now = datetime.datetime.utcnow()
+            filename = "statistics_" + now.strftime("%Y-%m-%d_%H%M%S") + ".pkl"
+            filename = os.path.expanduser(os.path.join(self.config.OUTPUT_DIR, filename))
+        return filename
+
+    def save(self, filename=""):
+        filename = self.get_filename(filename)
+        print("Save results to '%s'" % filename)
+        with open(filename, 'wb') as fd:
+            # pickle.dump(self.get_results(), fd)
+            pickle.dump(self, fd)

--- a/qstrader/trading_session/backtest.py
+++ b/qstrader/trading_session/backtest.py
@@ -64,13 +64,13 @@ class Backtest(object):
                         self.cur_time = event.time
                         self.strategy.calculate_signals(event)
                         self.portfolio_handler.update_portfolio_value()
-                        self.statistics.update(event.time)
+                        self.statistics.update(event.time, self.portfolio_handler)
                         ticks += 1
                     elif event.type == EventType.BAR:
                         self.cur_time = event.time
                         self.strategy.calculate_signals(event)
                         self.portfolio_handler.update_portfolio_value()
-                        self.statistics.update(event.time)
+                        self.statistics.update(event.time, self.portfolio_handler)
                         bars += 1
                     elif event.type == EventType.SIGNAL:
                         self.portfolio_handler.on_signal(event)

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 from test_portfolio import PriceHandlerMock
 
+from qstrader import settings
 from qstrader.portfolio import Portfolio
 from qstrader.statistics.simple import SimpleStatistics
 
@@ -22,6 +23,8 @@ class TestSimpleStatistics(unittest.TestCase):
     arithmetic for equity, return and drawdown
     calculations along the way.
     """
+    def setUp(self):
+        self.config = settings.TEST
 
     def test_calculating_statistics(self):
         """
@@ -35,7 +38,7 @@ class TestSimpleStatistics(unittest.TestCase):
         self.portfolio = Portfolio(price_handler, Decimal("500000.00"))
 
         portfolio_handler = PortfolioHandlerMock(self.portfolio)
-        statistics = SimpleStatistics(portfolio_handler)
+        statistics = SimpleStatistics(self.config, portfolio_handler)
 
         # Perform transaction and test statistics at this tick
         self.portfolio.transact_position(
@@ -43,7 +46,7 @@ class TestSimpleStatistics(unittest.TestCase):
             Decimal("566.56"), Decimal("1.00")
         )
         t = "2000-01-01 00:00:00"
-        statistics.update(t)
+        statistics.update(t, portfolio_handler)
         self.assertEqual(statistics.equity[t], Decimal("499807.00"))
         self.assertEqual(statistics.drawdowns[t], Decimal("193.00"))
         self.assertEqual(statistics.equity_returns[t], Decimal("-0.0386"))
@@ -55,7 +58,7 @@ class TestSimpleStatistics(unittest.TestCase):
             ("566.395"), Decimal("1.00")
         )
         t = "2000-01-02 00:00:00"
-        statistics.update(t)
+        statistics.update(t, portfolio_handler)
         self.assertEqual(statistics.equity[t], Decimal("499455.00"))
         self.assertEqual(statistics.drawdowns[t], Decimal("545.00"))
         self.assertEqual(statistics.equity_returns[t], Decimal("-0.0705"))
@@ -66,7 +69,7 @@ class TestSimpleStatistics(unittest.TestCase):
             Decimal("707.50"), Decimal("1.00")
         )
         t = "2000-01-03 00:00:00"
-        statistics.update(t)
+        statistics.update(t, portfolio_handler)
         self.assertEqual(statistics.equity[t], Decimal("499046.00"))
         self.assertEqual(statistics.drawdowns[t], Decimal("954.00"))
         self.assertEqual(statistics.equity_returns[t], Decimal("-0.0820"))
@@ -77,7 +80,7 @@ class TestSimpleStatistics(unittest.TestCase):
             Decimal("565.83"), Decimal("1.00")
         )
         t = "2000-01-04 00:00:00"
-        statistics.update(t)
+        statistics.update(t, portfolio_handler)
         self.assertEqual(statistics.equity[t], Decimal("499164.00"))
         self.assertEqual(statistics.drawdowns[t], Decimal("836.00"))
         self.assertEqual(statistics.equity_returns[t], Decimal("0.0236"))
@@ -88,7 +91,7 @@ class TestSimpleStatistics(unittest.TestCase):
             Decimal("705.545"), Decimal("1.00")
         )
         t = "2000-01-05 00:00:00"
-        statistics.update(t)
+        statistics.update(t, portfolio_handler)
         self.assertEqual(statistics.equity[t], Decimal("499146.00"))
         self.assertEqual(statistics.drawdowns[t], Decimal("854.00"))
         self.assertEqual(statistics.equity_returns[t], Decimal("-0.0036"))
@@ -99,7 +102,7 @@ class TestSimpleStatistics(unittest.TestCase):
             Decimal("565.59"), Decimal("1.00")
         )
         t = "2000-01-06 00:00:00"
-        statistics.update(t)
+        statistics.update(t, portfolio_handler)
         self.assertEqual(statistics.equity[t], Decimal("499335.00"))
         self.assertEqual(statistics.drawdowns[t], Decimal("665.00"))
         self.assertEqual(statistics.equity_returns[t], Decimal("0.0379"))
@@ -110,7 +113,7 @@ class TestSimpleStatistics(unittest.TestCase):
             Decimal("707.92"), Decimal("1.00")
         )
         t = "2000-01-07 00:00:00"
-        statistics.update(t)
+        statistics.update(t, portfolio_handler)
         self.assertEqual(statistics.equity[t], Decimal("499580.00"))
         self.assertEqual(statistics.drawdowns[t], Decimal("420.00"))
         self.assertEqual(statistics.equity_returns[t], Decimal("0.0490"))
@@ -121,7 +124,7 @@ class TestSimpleStatistics(unittest.TestCase):
             Decimal("707.90"), Decimal("0.00")
         )
         t = "2000-01-08 00:00:00"
-        statistics.update(t)
+        statistics.update(t, portfolio_handler)
         self.assertEqual(statistics.equity[t], Decimal("499824.00"))
         self.assertEqual(statistics.drawdowns[t], Decimal("176.00"))
         self.assertEqual(statistics.equity_returns[t], Decimal("0.0488"))
@@ -132,7 +135,7 @@ class TestSimpleStatistics(unittest.TestCase):
             Decimal("707.92"), Decimal("0.50")
         )
         t = "2000-01-09 00:00:00"
-        statistics.update(t)
+        statistics.update(t, portfolio_handler)
         self.assertEqual(statistics.equity[t], Decimal("500069.50"))
         self.assertEqual(statistics.drawdowns[t], Decimal("00.00"))
         self.assertEqual(statistics.equity_returns[t], Decimal("0.0491"))
@@ -143,7 +146,7 @@ class TestSimpleStatistics(unittest.TestCase):
             Decimal("707.78"), Decimal("1.00")
         )
         t = "2000-01-10 00:00:00"
-        statistics.update(t)
+        statistics.update(t, portfolio_handler)
         self.assertEqual(statistics.equity[t], Decimal("500300.50"))
         self.assertEqual(statistics.drawdowns[t], Decimal("00.00"))
         self.assertEqual(statistics.equity_returns[t], Decimal("0.0462"))


### PR DESCRIPTION
Close #82

This PR envolved some changes into Statistics method such as update
to avoid to serialize unecessary stuff.

Statistics can be easily retrieved using:

```python
from qstrader.statistics import load
stats = load("output_directory/statistics_yyyy-mm-dd_HHMMSS.pkl")
```

Bokeh TimeSeries plot may be improved according 
https://github.com/bokeh/bokeh/issues/4747

Other interactive plotting libraries can also if we can't fix this.