### PR TITLE
Fix statistics timeline

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -3,7 +3,7 @@ Test examples
 
 One example can be test individually using:
 
-$ nosetests -s -v tests/test_examples.py:TestExamples.test_strategy_backtest
+$ nosetests -s -v examples/test_examples.py:TestExamples.test_strategy_backtest
 
 """
 import os
@@ -37,7 +37,7 @@ class TestExamples(unittest.TestCase):
         filename = os.path.join(settings.TEST.OUTPUT_DIR, "buy_and_hold_backtest.pkl")
         results = examples.buy_and_hold_backtest.run(self.config, self.testing, tickers, filename)
         for (key, expected) in [
-            ('sharpe', 0.5969),
+            ('sharpe', 0.5968),
             ('max_drawdown_pct', 5.0308),
             ('max_drawdown', 30174.01)
         ]:
@@ -54,7 +54,7 @@ class TestExamples(unittest.TestCase):
             # self.assertAlmostEqual(float(values.iloc[-1]), expected['last']) # TODO FAILING BY 1 CENT
         stats = load(filename)
         results = stats.get_results()
-        self.assertAlmostEqual(float(results['sharpe']), 0.5969)
+        self.assertAlmostEqual(float(results['sharpe']), 0.5968)
 
     def test_mac_backtest(self):
         """
@@ -63,7 +63,7 @@ class TestExamples(unittest.TestCase):
         tickers = ["SP500TR"]
         filename = os.path.join(settings.TEST.OUTPUT_DIR, "mac_backtest.pkl")
         results = examples.mac_backtest.run(self.config, self.testing, tickers, filename)
-        self.assertAlmostEqual(float(results['sharpe']), 0.6018)
+        self.assertAlmostEqual(float(results['sharpe']), 0.6016)
 
     def test_strategy_backtest(self):
         """
@@ -72,4 +72,4 @@ class TestExamples(unittest.TestCase):
         tickers = ["GOOG"]
         filename = os.path.join(settings.TEST.OUTPUT_DIR, "strategy_backtest.pkl")
         results = examples.strategy_backtest.run(self.config, self.testing, tickers, filename)
-        self.assertAlmostEqual(float(results['sharpe']), -7.5299)
+        self.assertAlmostEqual(float(results['sharpe']), -7.1351)

--- a/qstrader/statistics/simple.py
+++ b/qstrader/statistics/simple.py
@@ -39,7 +39,8 @@ class SimpleStatistics(AbstractStatistics):
         self.config = config
         self.drawdowns = [0]
         self.equity = []
-        self.equity_returns = []
+        self.equity_returns = [0.0]
+        self.timeseries = ["0000-00-00 00:00:00"]
         # Initialize in order for first-step calculations to be correct.
         current_equity = PriceParser.display(portfolio_handler.portfolio.equity)
         self.hwm = [current_equity]
@@ -52,6 +53,7 @@ class SimpleStatistics(AbstractStatistics):
         # Retrieve equity value of Portfolio
         current_equity = PriceParser.display(portfolio_handler.portfolio.equity)
         self.equity.append(current_equity)
+        self.timeseries.append(timestamp)
 
         if(len(self.equity) > 1):
             # Calculate percentage return between current and previous equity value.
@@ -67,11 +69,11 @@ class SimpleStatistics(AbstractStatistics):
         """
         statistics = {}
         statistics["sharpe"] = self.calculate_sharpe()
-        statistics["drawdowns"] = pd.Series(self.drawdowns)
+        statistics["drawdowns"] = pd.Series(self.drawdowns, index=self.timeseries)
         statistics["max_drawdown"] = max(self.drawdowns)
         statistics["max_drawdown_pct"] = self.calculate_max_drawdown_pct()
-        statistics["equity"] = pd.Series(self.equity)
-        statistics["equity_returns"] = pd.Series(self.equity_returns)
+        statistics["equity"] = pd.Series(self.equity, index=self.timeseries)
+        statistics["equity_returns"] = pd.Series(self.equity_returns, index=self.timeseries)
         return statistics
 
     def calculate_sharpe(self, benchmark_return=0.00):
@@ -125,9 +127,9 @@ class SimpleStatistics(AbstractStatistics):
         fig.patch.set_facecolor('white')
 
         df = pd.DataFrame()
-        df["equity"] = pd.Series(self.equity)
-        df["equity_returns"] = pd.Series(self.equity_returns)
-        df["drawdowns"] = pd.Series(self.drawdowns)
+        df["equity"] = pd.Series(self.equity, index=self.timeseries)
+        df["equity_returns"] = pd.Series(self.equity_returns, index=self.timeseries)
+        df["drawdowns"] = pd.Series(self.drawdowns, index=self.timeseries)
 
         # Plot the equity curve
         ax1 = fig.add_subplot(311, ylabel='Equity Value')
@@ -140,6 +142,9 @@ class SimpleStatistics(AbstractStatistics):
         # drawdown, max_dd, dd_duration = self.create_drawdowns(df["Equity"])
         ax3 = fig.add_subplot(313, ylabel='Drawdowns')
         df['drawdowns'].plot(ax=ax3, color=sns.color_palette()[2])
+
+        # Rotate dates
+        fig.autofmt_xdate()
 
         # Plot the figure
         plt.show()

--- a/qstrader/statistics/simple.py
+++ b/qstrader/statistics/simple.py
@@ -50,12 +50,12 @@ class SimpleStatistics(AbstractStatistics):
         """
         Update all statistics that must be tracked over time.
         """
-        # Retrieve equity value of Portfolio
-        current_equity = PriceParser.display(portfolio_handler.portfolio.equity)
-        self.equity.append(current_equity)
-        self.timeseries.append(timestamp)
+        if timestamp != self.timeseries[-1]:
+            # Retrieve equity value of Portfolio
+            current_equity = PriceParser.display(portfolio_handler.portfolio.equity)
+            self.equity.append(current_equity)
+            self.timeseries.append(timestamp)
 
-        if(len(self.equity) > 1):
             # Calculate percentage return between current and previous equity value.
             pct = ((self.equity[-1] - self.equity[-2]) / self.equity[-1]) * 100
             self.equity_returns.append(round(pct, 4))
@@ -74,6 +74,7 @@ class SimpleStatistics(AbstractStatistics):
         statistics["max_drawdown_pct"] = self.calculate_max_drawdown_pct()
         statistics["equity"] = pd.Series(self.equity, index=self.timeseries)
         statistics["equity_returns"] = pd.Series(self.equity_returns, index=self.timeseries)
+
         return statistics
 
     def calculate_sharpe(self, benchmark_return=0.00):

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ click>=6.6
 pyyaml>=3.11
 munch>=2.0.4
 enum34>=1.1.6
+multipledispatch>=0.4.8

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -40,6 +40,11 @@ class TestSimpleStatistics(unittest.TestCase):
         portfolio_handler = PortfolioHandlerMock(self.portfolio)
         statistics = SimpleStatistics(self.config, portfolio_handler)
 
+        # Check initialization was correct
+        self.assertEqual(PriceParser.display(statistics.equity[0]), 500000.00)
+        self.assertEqual(PriceParser.display(statistics.drawdowns[0]), 00)
+        self.assertEqual(statistics.equity_returns[0], 0.0)
+
         # Perform transaction and test statistics at this tick
         self.portfolio.transact_position(
             "BOT", "AMZN", 100,
@@ -49,7 +54,7 @@ class TestSimpleStatistics(unittest.TestCase):
         statistics.update(t, portfolio_handler)
         self.assertEqual(PriceParser.display(statistics.equity[1]), 499807.00)
         self.assertEqual(PriceParser.display(statistics.drawdowns[1]), 193.00)
-        self.assertEqual(statistics.equity_returns[0], -0.0386)
+        self.assertEqual(statistics.equity_returns[1], -0.0386)
 
         # Perform transaction and test statistics at this tick
         self.portfolio.transact_position(
@@ -60,7 +65,7 @@ class TestSimpleStatistics(unittest.TestCase):
         statistics.update(t, portfolio_handler)
         self.assertEqual(PriceParser.display(statistics.equity[2]), 499455.00)
         self.assertEqual(PriceParser.display(statistics.drawdowns[2]), 545.00)
-        self.assertEqual(statistics.equity_returns[1], -0.0705)
+        self.assertEqual(statistics.equity_returns[2], -0.0705)
 
         # Perform transaction and test statistics at this tick
         self.portfolio.transact_position(
@@ -71,7 +76,7 @@ class TestSimpleStatistics(unittest.TestCase):
         statistics.update(t, portfolio_handler)
         self.assertEqual(PriceParser.display(statistics.equity[3]), 499046.00)
         self.assertEqual(PriceParser.display(statistics.drawdowns[3]), 954.00)
-        self.assertEqual(statistics.equity_returns[2], -0.0820)
+        self.assertEqual(statistics.equity_returns[3], -0.0820)
 
         # Perform transaction and test statistics at this tick
         self.portfolio.transact_position(
@@ -82,7 +87,7 @@ class TestSimpleStatistics(unittest.TestCase):
         statistics.update(t, portfolio_handler)
         self.assertEqual(PriceParser.display(statistics.equity[4]), 499164.00)
         self.assertEqual(PriceParser.display(statistics.drawdowns[4]), 836.00)
-        self.assertEqual(statistics.equity_returns[3], 0.0236)
+        self.assertEqual(statistics.equity_returns[4], 0.0236)
 
         # Perform transaction and test statistics at this tick
         self.portfolio.transact_position(
@@ -93,7 +98,7 @@ class TestSimpleStatistics(unittest.TestCase):
         statistics.update(t, portfolio_handler)
         self.assertEqual(PriceParser.display(statistics.equity[5]), 499146.00)
         self.assertEqual(PriceParser.display(statistics.drawdowns[5]), 854.00)
-        self.assertEqual(statistics.equity_returns[4], -0.0036)
+        self.assertEqual(statistics.equity_returns[5], -0.0036)
 
         # Perform transaction and test statistics at this tick
         self.portfolio.transact_position(
@@ -104,7 +109,7 @@ class TestSimpleStatistics(unittest.TestCase):
         statistics.update(t, portfolio_handler)
         self.assertEqual(PriceParser.display(statistics.equity[6]), 499335.00)
         self.assertEqual(PriceParser.display(statistics.drawdowns[6]), 665.00)
-        self.assertEqual(statistics.equity_returns[5], 0.0379)
+        self.assertEqual(statistics.equity_returns[6], 0.0379)
 
         # Perform transaction and test statistics at this tick
         self.portfolio.transact_position(
@@ -115,7 +120,7 @@ class TestSimpleStatistics(unittest.TestCase):
         statistics.update(t, portfolio_handler)
         self.assertEqual(PriceParser.display(statistics.equity[7]), 499580.00)
         self.assertEqual(PriceParser.display(statistics.drawdowns[7]), 420.00)
-        self.assertEqual(statistics.equity_returns[6], 0.0490)
+        self.assertEqual(statistics.equity_returns[7], 0.0490)
 
         # Perform transaction and test statistics at this tick
         self.portfolio.transact_position(
@@ -126,7 +131,7 @@ class TestSimpleStatistics(unittest.TestCase):
         statistics.update(t, portfolio_handler)
         self.assertEqual(PriceParser.display(statistics.equity[8]), 499824.00)
         self.assertEqual(PriceParser.display(statistics.drawdowns[8]), 176.00)
-        self.assertEqual(statistics.equity_returns[7], 0.0488)
+        self.assertEqual(statistics.equity_returns[8], 0.0488)
 
         # Perform transaction and test statistics at this tick
         self.portfolio.transact_position(
@@ -137,7 +142,7 @@ class TestSimpleStatistics(unittest.TestCase):
         statistics.update(t, portfolio_handler)
         self.assertEqual(PriceParser.display(statistics.equity[9]), 500069.50)
         self.assertEqual(PriceParser.display(statistics.drawdowns[9]), 00.00)
-        self.assertEqual(statistics.equity_returns[8], 0.0491)
+        self.assertEqual(statistics.equity_returns[9], 0.0491)
 
         # Perform transaction and test statistics at this tick
         self.portfolio.transact_position(
@@ -148,13 +153,13 @@ class TestSimpleStatistics(unittest.TestCase):
         statistics.update(t, portfolio_handler)
         self.assertEqual(PriceParser.display(statistics.equity[10]), 500300.50)
         self.assertEqual(PriceParser.display(statistics.drawdowns[10]), 00.00)
-        self.assertEqual(statistics.equity_returns[9], 0.0462)
+        self.assertEqual(statistics.equity_returns[10], 0.0462)
 
         # Test that results are calculated correctly.
         results = statistics.get_results()
         self.assertEqual(results["max_drawdown"], 954.00)
         self.assertEqual(results["max_drawdown_pct"], 0.1908)
-        self.assertAlmostEqual(float(results["sharpe"]), 1.8353)
+        self.assertAlmostEqual(float(results["sharpe"]), 1.7575)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
After arithmetic optimisation, Statistics wasn't using Timestamps to index the `equity`, `drawdown`, `equity_returns` lists internally. This meant that final graphs simply had `n` on the X axis, where `n` is the number of bars run.

We now also keep a list of `timeseries` where we just add the timestamp. When these items are requested, a Pandas Series object is created with the list, indexed by `self.timeseries`.

`Statistics.update()` will now only add an item to the internal lists if the timestamp is newer than the latest timestamp, to ensure we don't keep duplicate values.