### PR TITLE
Closed positions

### DIFF
--- a/qstrader/portfolio.py
+++ b/qstrader/portfolio.py
@@ -16,7 +16,7 @@ class Portfolio(object):
         self.init_cash = cash
         self.cur_cash = cash
         self.positions = {}
-        self.closed_positions = {}
+        self.closed_positions = []
         self.closed_pnl = 0
         self._reset_values()
 
@@ -125,8 +125,7 @@ class Portfolio(object):
             if self.positions[ticker].quantity == 0:
                 closed = self.positions.pop(ticker)
                 self.closed_pnl += closed.realised_pnl
-                # TODO what if this overrides a position... ? Maybe list better than dict. For both. Also because
-                self.closed_positions[closed.ticker] = closed
+                self.closed_positions.append(closed)
 
             self._update_portfolio()
         else:

--- a/qstrader/portfolio.py
+++ b/qstrader/portfolio.py
@@ -30,8 +30,8 @@ class Portfolio(object):
         All cash is reset to the initial values and the
         PnL is set to zero.
         """
-        self.cur_cash = self.init_cash
-        self.equity = self.cur_cash
+        # self.cur_cash = self.init_cash
+        self.equity = self.init_cash
         self.realised_pnl = 0
         self.unrealised_pnl = 0
 
@@ -44,7 +44,7 @@ class Portfolio(object):
         This method is called after every Position modification.
         """
         self.equity = self.closed_pnl
-        self.equity += self.cur_cash
+        self.equity += self.init_cash
 
         for ticker in self.positions:
             pt = self.positions[ticker]
@@ -56,9 +56,9 @@ class Portfolio(object):
                 ask = close_price
             pt.update_market_value(bid, ask)
             self.unrealised_pnl += pt.unrealised_pnl
-            self.cur_cash -= pt.cost_basis
+            # self.cur_cash -= pt.cost_basis
             pnl_diff = pt.realised_pnl - pt.unrealised_pnl
-            self.cur_cash += pnl_diff
+            # self.cur_cash += pnl_diff
             self.equity += (
                 pt.market_value - pt.cost_basis + pnl_diff
             )
@@ -147,6 +147,12 @@ class Portfolio(object):
         Hence, this single method will be called by the
         PortfolioHandler to update the Portfolio itself.
         """
+
+        if action == "BOT":
+            self.cur_cash -= ((quantity * price) + commission)
+        elif action == "SLD":
+            self.cur_cash += ((quantity * price) + commission)
+
         if ticker not in self.positions:
             self._add_position(
                 action, ticker, quantity,

--- a/qstrader/portfolio.py
+++ b/qstrader/portfolio.py
@@ -17,7 +17,7 @@ class Portfolio(object):
         self.cur_cash = cash
         self.positions = {}
         self.closed_positions = []
-        self.closed_pnl = 0
+        self.realised_pnl = 0
         self._reset_values()
 
     def _reset_values(self):
@@ -30,9 +30,7 @@ class Portfolio(object):
         All cash is reset to the initial values and the
         PnL is set to zero.
         """
-        # self.cur_cash = self.init_cash
         self.equity = self.init_cash
-        self.realised_pnl = 0
         self.unrealised_pnl = 0
 
     def _update_portfolio(self):
@@ -43,7 +41,7 @@ class Portfolio(object):
 
         This method is called after every Position modification.
         """
-        self.equity = self.closed_pnl
+        self.equity = self.realised_pnl
         self.equity += self.init_cash
 
         for ticker in self.positions:
@@ -124,7 +122,7 @@ class Portfolio(object):
 
             if self.positions[ticker].quantity == 0:
                 closed = self.positions.pop(ticker)
-                self.closed_pnl += closed.realised_pnl
+                self.realised_pnl += closed.realised_pnl
                 self.closed_positions.append(closed)
 
             self._update_portfolio()
@@ -150,7 +148,7 @@ class Portfolio(object):
         if action == "BOT":
             self.cur_cash -= ((quantity * price) + commission)
         elif action == "SLD":
-            self.cur_cash += ((quantity * price) + commission)
+            self.cur_cash += ((quantity * price) - commission)
 
         if ticker not in self.positions:
             self._add_position(

--- a/qstrader/portfolio_handler.py
+++ b/qstrader/portfolio_handler.py
@@ -119,5 +119,4 @@ class PortfolioHandler(object):
         Update the portfolio to reflect current market value as
         based on last bid/ask of each ticker.
         """
-        self.portfolio._reset_values()
         self.portfolio._update_portfolio()

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -92,6 +92,8 @@ class TestAmazonGooglePortfolio(unittest.TestCase):
         # The figures below are derived from Interactive Brokers
         # demo account using the above trades with prices provided
         # by their demo feed.
+        self.assertEqual(len(self.portfolio.positions), 0)
+        self.assertEqual(len(self.portfolio.closed_positions), 2)
         self.assertEqual(PriceParser.display(self.portfolio.cur_cash), 499100.50)
         self.assertEqual(PriceParser.display(self.portfolio.equity), 499100.50)
         self.assertEqual(PriceParser.display(self.portfolio.unrealised_pnl), 0.00)


### PR DESCRIPTION
Ryan, shouldn't self.close_positions be a list of all the close `Positions` classes instead of a dict with tickers?

When the position is closed, it should get added to the list.  If at the end the backtest the position is still open, it also needs to be appended at the end with status 'open'.