### PR TITLE
Tearsheet Statistics Class

### DIFF
--- a/examples/mac_backtest_tearsheet.py
+++ b/examples/mac_backtest_tearsheet.py
@@ -1,0 +1,86 @@
+import click
+
+from qstrader import settings
+from qstrader.compat import queue
+from qstrader.price_parser import PriceParser
+from qstrader.price_handler.yahoo_daily_csv_bar import YahooDailyCsvBarPriceHandler
+from qstrader.strategy.moving_average_cross_strategy import MovingAverageCrossStrategy
+from qstrader.position_sizer.fixed import FixedPositionSizer
+from qstrader.risk_manager.example import ExampleRiskManager
+from qstrader.portfolio_handler import PortfolioHandler
+from qstrader.compliance.example import ExampleCompliance
+from qstrader.execution_handler.ib_simulated import IBSimulatedExecutionHandler
+from qstrader.statistics.tearsheet import TearsheetStatistics
+from qstrader.trading_session.backtest import Backtest
+
+
+def run(config, testing, tickers, filename):
+
+    # Benchmark ticker
+    benchmark = 'SP500TR'
+
+    # Set up variables needed for backtest
+    title = ['Moving Average Crossover Example',
+             __file__,
+             ','.join(tickers) + ': 100x400'
+            ]
+    events_queue = queue.Queue()
+    csv_dir = config.CSV_DATA_DIR
+    initial_equity = PriceParser.parse(500000.00)
+
+    # Use Yahoo Daily Price Handler
+    price_handler = YahooDailyCsvBarPriceHandler(
+        csv_dir, events_queue, tickers
+    )
+
+    # Use the MAC Strategy
+    strategy = MovingAverageCrossStrategy(tickers, events_queue)
+
+    # Use an example Position Sizer,
+    position_sizer = FixedPositionSizer()
+
+    # Use an example Risk Manager,
+    risk_manager = ExampleRiskManager()
+
+    # Use the default Portfolio Handler
+    portfolio_handler = PortfolioHandler(
+        initial_equity, events_queue, price_handler,
+        position_sizer, risk_manager
+    )
+
+    # Use the ExampleCompliance component
+    compliance = ExampleCompliance(config)
+
+    # Use a simulated IB Execution Handler
+    execution_handler = IBSimulatedExecutionHandler(
+        events_queue, price_handler, compliance
+    )
+
+    # Use the default Statistics
+    statistics = TearsheetStatistics(
+        config, portfolio_handler, title, benchmark
+    )
+
+    # Set up the backtest
+    backtest = Backtest(
+        price_handler, strategy,
+        portfolio_handler, execution_handler,
+        position_sizer, risk_manager,
+        statistics, initial_equity
+    )
+    results = backtest.simulate_trading(testing=testing)
+    return results
+
+
+@click.command()
+@click.option('--config', default=settings.DEFAULT_CONFIG_FILENAME, help='Config filename')
+@click.option('--testing/--no-testing', default=False, help='Enable testing mode')
+@click.option('--tickers', default='SP500TR', help='Tickers (use comma)')
+@click.option('--filename', default='', help='Pickle (.pkl) statistics filename')
+def main(config, testing, tickers, filename):
+    tickers = tickers.split(",")
+    config = settings.from_file(config, testing)
+    run(config, testing, tickers, filename)
+
+if __name__ == "__main__":
+    main()

--- a/examples/mac_backtest_tearsheet.py
+++ b/examples/mac_backtest_tearsheet.py
@@ -20,10 +20,11 @@ def run(config, testing, tickers, filename):
     benchmark = 'SP500TR'
 
     # Set up variables needed for backtest
-    title = ['Moving Average Crossover Example',
-             __file__,
-             ','.join(tickers) + ': 100x400'
-            ]
+    title = [
+        'Moving Average Crossover Example',
+        __file__,
+        ','.join(tickers) + ': 100x400'
+    ]
     events_queue = queue.Queue()
     csv_dir = config.CSV_DATA_DIR
     initial_equity = PriceParser.parse(500000.00)

--- a/examples/mac_backtest_tearsheet.py
+++ b/examples/mac_backtest_tearsheet.py
@@ -70,6 +70,7 @@ def run(config, testing, tickers, filename):
         statistics, initial_equity
     )
     results = backtest.simulate_trading(testing=testing)
+    statistics.save(filename)
     return results
 
 

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -15,6 +15,7 @@ from qstrader.statistics import load
 import examples.display_prices_backtest
 import examples.buy_and_hold_backtest
 import examples.mac_backtest
+import examples.mac_backtest_tearsheet
 import examples.strategy_backtest
 
 
@@ -78,6 +79,15 @@ class TestExamples(unittest.TestCase):
         filename = os.path.join(settings.TEST.OUTPUT_DIR, "mac_backtest.pkl")
         results = examples.mac_backtest.run(self.config, self.testing, tickers, filename)
         self.assertAlmostEqual(float(results['sharpe']), 0.6016)
+
+    def test_mac_backtest_tearsheet(self):
+        """
+        Test mac_backtest_tearsheet example
+        """
+        tickers = ["SP500TR"]
+        filename = os.path.join(settings.TEST.OUTPUT_DIR, "mac_backtest_tearsheet.pkl")
+        results = examples.mac_backtest_tearsheet.run(self.config, self.testing, tickers, filename)
+        self.assertAlmostEqual(float(results['sharpe']), 0.639220566475)
 
     def test_strategy_backtest(self):
         """

--- a/qstrader/statistics/performance.py
+++ b/qstrader/statistics/performance.py
@@ -37,7 +37,7 @@ def create_cagr(equity, periods=252):
     periods - Daily (252), Hourly (252*6.5), Minutely(252*6.5*60) etc.
     """
     years = len(equity) / float(periods)
-    return (equity[-1]**(1.0/years))-1.0
+    return (equity[-1] ** (1.0 / years)) - 1.0
 
 
 def create_sharpe_ratio(returns, periods=252):
@@ -88,9 +88,9 @@ def create_drawdowns(returns):
 
     # Loop over the index range
     for t in range(1, len(idx)):
-        hwm.append(max(hwm[t-1], returns.ix[t]))
+        hwm.append(max(hwm[t - 1], returns.ix[t]))
         drawdown.ix[t] = (hwm[t] - returns.ix[t]) / hwm[t]
-        duration.ix[t] = (0 if drawdown.ix[t] == 0 else duration.ix[t-1] + 1)
+        duration.ix[t] = (0 if drawdown.ix[t] == 0 else duration.ix[t - 1] + 1)
 
     return drawdown, drawdown.max(), duration.max()
 

--- a/qstrader/statistics/performance.py
+++ b/qstrader/statistics/performance.py
@@ -1,0 +1,102 @@
+import numpy as np
+import pandas as pd
+from scipy.stats import linregress
+
+
+def aggregate_returns(returns, convert_to):
+    """
+    Aggregates returns by day, week, month, or year.
+    """
+    def cumulate_returns(x):
+        return np.exp(np.log(1 + x).cumsum())[-1] - 1
+
+    if convert_to == 'weekly':
+        return returns.groupby(
+            [lambda x: x.year,
+             lambda x: x.month,
+             lambda x: x.isocalendar()[1]]).apply(cumulate_returns)
+    elif convert_to == 'monthly':
+        return returns.groupby(
+            [lambda x: x.year, lambda x: x.month]).apply(cumulate_returns)
+    elif convert_to == 'yearly':
+        return returns.groupby(
+            [lambda x: x.year]).apply(cumulate_returns)
+    else:
+        ValueError('convert_to must be weekly, monthly or yearly')
+
+
+def create_cagr(equity, periods=252):
+    """
+    Calculates the Compound Annual Growth Rate (CAGR)
+    for the portfolio, by determining the number of years
+    and then creating a compound annualised rate based
+    on the total return.
+
+    Parameters:
+    equity - A pandas Series representing the equity curve.
+    periods - Daily (252), Hourly (252*6.5), Minutely(252*6.5*60) etc.
+    """
+    years = len(equity) / float(periods)
+    return (equity[-1]**(1.0/years))-1.0
+
+
+def create_sharpe_ratio(returns, periods=252):
+    """
+    Create the Sharpe ratio for the strategy, based on a
+    benchmark of zero (i.e. no risk-free rate information).
+
+    Parameters:
+    returns - A pandas Series representing period percentage returns.
+    periods - Daily (252), Hourly (252*6.5), Minutely(252*6.5*60) etc.
+    """
+    return np.sqrt(periods) * (np.mean(returns)) / np.std(returns)
+
+
+def create_sortino_ratio(returns, periods=252):
+    """
+    Create the Sortino ratio for the strategy, based on a
+    benchmark of zero (i.e. no risk-free rate information).
+
+    Parameters:
+    returns - A pandas Series representing period percentage returns.
+    periods - Daily (252), Hourly (252*6.5), Minutely(252*6.5*60) etc.
+    """
+    return np.sqrt(periods) * (np.mean(returns)) / np.std(returns[returns < 0])
+
+
+def create_drawdowns(returns):
+    """
+    Calculate the largest peak-to-trough drawdown of the equity curve
+    as well as the duration of the drawdown. Requires that the
+    pnl_returns is a pandas Series.
+
+    Parameters:
+    equity - A pandas Series representing period percentage returns.
+
+    Returns:
+    drawdown, drawdown_max, duration
+    """
+
+    # Calculate the cumulative returns curve
+    # and set up the High Water Mark
+    hwm = [0]
+
+    # Create the drawdown and duration series
+    idx = returns.index
+    drawdown = pd.Series(index=idx)
+    duration = pd.Series(index=idx)
+
+    # Loop over the index range
+    for t in range(1, len(idx)):
+        hwm.append(max(hwm[t-1], returns.ix[t]))
+        drawdown.ix[t] = (hwm[t] - returns.ix[t]) / hwm[t]
+        duration.ix[t] = (0 if drawdown.ix[t] == 0 else duration.ix[t-1] + 1)
+
+    return drawdown, drawdown.max(), duration.max()
+
+
+def rsquared(x, y):
+    """ Return R^2 where x and y are array-like."""
+
+    slope, intercept, r_value, p_value, std_err = linregress(x, y)
+    return r_value**2

--- a/qstrader/statistics/tearsheet.py
+++ b/qstrader/statistics/tearsheet.py
@@ -3,6 +3,7 @@ from ..price_parser import PriceParser
 
 from matplotlib.ticker import FuncFormatter
 from matplotlib import cm
+from datetime import datetime
 
 import qstrader.statistics.performance as perf
 
@@ -12,6 +13,7 @@ import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 import matplotlib.dates as mdates
 import seaborn as sns
+import os
 
 
 class TearsheetStatistics(AbstractStatistics):
@@ -478,7 +480,7 @@ class TearsheetStatistics(AbstractStatistics):
         ax.axis([0, 10, 0, 10])
         return ax
 
-    def plot_results(self):
+    def plot_results(self, filename=None):
         """
         Plot the Tearsheet
         """
@@ -527,3 +529,17 @@ class TearsheetStatistics(AbstractStatistics):
 
         # Plot the figure
         plt.show()
+
+        if filename is not None:
+            fig.savefig(filename)
+
+    def get_filename(self, filename=""):
+        if filename == "":
+            now = datetime.utcnow()
+            filename = "tearsheet_" + now.strftime("%Y-%m-%d_%H%M%S") + ".png"
+            filename = os.path.expanduser(os.path.join(self.config.OUTPUT_DIR, filename))
+        return filename
+
+    def save(self, filename=""):
+        filename = self.get_filename(filename)
+        self.plot_results

--- a/qstrader/statistics/tearsheet.py
+++ b/qstrader/statistics/tearsheet.py
@@ -1,0 +1,360 @@
+from .base import AbstractStatistics
+from ..compat import pickle
+from ..price_parser import PriceParser
+
+from datetime import datetime
+from matplotlib.ticker import FuncFormatter
+from matplotlib import cm
+
+import qstrader.statistics.performance as perf
+
+import os
+import math
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
+import matplotlib.dates as mdates
+import seaborn as sns
+
+
+class TearsheetStatistics(AbstractStatistics):
+    """
+    """
+    def __init__(self, config, portfolio_handler, title=None, benchmark=None):
+        """
+        Takes in a portfolio handler.
+        """
+        self.config = config
+        self.portfolio_handler = portfolio_handler
+        self.title = '\n'.join(title)
+        self.benchmark = benchmark
+        self.equity = {}
+        self.equity_benchmark = {}
+        self.log_scale = False
+
+
+    def update(self, timestamp, portfolio_handler):
+        """
+        Update all statistics that must be tracked over time.
+        """
+        self.equity[timestamp] = PriceParser.display(
+            portfolio_handler.portfolio.equity
+        )
+
+
+    def get_results(self):
+        """
+        Return a dict with all important results & stats.
+        """
+        # Equity
+        equity_s = pd.Series(self.equity).sort_index()
+
+        # Returns
+        returns_s = equity_s.pct_change().fillna(0.0)
+
+        # Cummulative Returns
+        cum_returns_s = np.exp(np.log(1 + returns_s).cumsum())
+
+        # Drawdown, max drawdown, max drawdown duration
+        dd_s, max_dd, dd_dur = perf.create_drawdowns(cum_returns_s)
+
+        statistics = {}
+        statistics["sharpe"] = perf.create_sharpe_ratio(returns_s)
+        statistics["drawdowns"] = dd_s
+        statistics["max_drawdown"] = max_dd  #TODO: is DD amt really needed?
+        statistics["max_drawdown_pct"] = max_dd
+        statistics["max_drawdown_duration"] = dd_dur
+        statistics["equity"] = equity_s
+        statistics["returns"] = returns_s
+        statistics["cum_returns"] = cum_returns_s
+
+        return statistics
+
+
+    def _get_positions(self):
+        """
+        Retrieve the list of closed Positions objects from the portfolio
+        and reformat into a pandas dataframe to be returned
+        """
+        pos = self.portfolio_handler.portfolio.closed_positions
+        a = []
+        for p in pos:
+            a.append(p.__dict__)
+
+        df = pd.DataFrame(a)
+        x = lambda x: PriceParser.display(x)
+
+        df['avg_bot'] = df['avg_bot'].apply(x)
+        df['avg_price'] = df['avg_price'].apply(x)
+        df['avg_sld'] = df['avg_sld'].apply(x)
+        df['cost_basis'] = df['cost_basis'].apply(x)
+        df['init_commission'] = df['init_commission'].apply(x)
+        df['init_price'] = df['init_price'].apply(x)
+        df['market_value'] = df['market_value'].apply(x)
+        df['net'] = df['net'].apply(x)
+        df['net_incl_comm'] = df['net_incl_comm'].apply(x)
+        df['net_total'] = df['net_total'].apply(x)
+        df['realised_pnl'] = df['realised_pnl'].apply(x)
+        df['total_bot'] = df['total_bot'].apply(x)
+        df['total_commission'] = df['total_commission'].apply(x)
+        df['total_sld'] = df['total_sld'].apply(x)
+        df['unrealised_pnl'] = df['unrealised_pnl'].apply(x)
+
+        return df
+
+
+    def _plot_equity(self, equity, benchmark=None, ax=None, **kwargs):
+        """
+        Plots cumulative rolling returns versus some benchmark.
+        """
+        def format_two_dec(x, pos): return '%.2f' % x
+
+        if ax is None:
+            ax = plt.gca()
+
+        y_axis_formatter = FuncFormatter(format_two_dec)
+        ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))
+        ax.xaxis.set_tick_params(reset=True)
+        ax.xaxis.set_major_locator(mdates.YearLocator(1))
+        ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))
+
+        """
+        if benchmark is not None:
+            benchmark.plot(
+                lw=2, color='gray', label='S&P500', alpha=0.60, ax=ax, **kwargs
+            )
+        """
+
+        equity.plot(lw=2, color='green', alpha=0.6, x_compat=False,
+                    label='Backtest', ax=ax, **kwargs)
+
+        ax.axhline(1.0, linestyle='--', color='black', lw=1)
+        ax.set_ylabel('Cumulative returns')
+        ax.legend(loc='best')
+        ax.set_xlabel('')
+
+        if self.log_scale:
+            ax.set_yscale('log')
+
+        return ax
+
+
+    def _plot_drawdown(self, drawdown, ax=None, **kwargs):
+        """
+        Plots the underwater curve
+        """
+        def format_perc(x, pos): return '%.0f%%' % x
+
+        if ax is None:
+            ax = plt.gca()
+
+        y_axis_formatter = FuncFormatter(format_perc)
+        ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))
+
+        underwater = -100 * drawdown
+        underwater.plot(ax=ax, lw=2, kind='area', color='red', alpha=0.3, **kwargs)
+        ax.set_ylabel('')
+        ax.set_xlabel('')
+        ax.set_title('Drawdown (%)', fontweight='bold')
+        return ax
+
+
+    def _plot_monthly_returns(self, returns, ax=None, **kwargs):
+        """
+        Plots a heatmap of the monthly returns.
+        """
+        if ax is None:
+            ax = plt.gca()
+
+        monthly_ret = perf.aggregate_returns(returns, 'monthly')
+        monthly_ret = monthly_ret.unstack()
+        monthly_ret = np.round(monthly_ret, 3)
+        monthly_ret.rename(columns={1: 'Jan', 2: 'Feb', 3: 'Mar', 4: 'Apr',
+                                    5: 'May', 6: 'Jun', 7: 'Jul', 8: 'Aug',
+                                    9: 'Sep', 10: 'Oct', 11: 'Nov', 12: 'Dec'},
+                                    inplace=True
+        )
+
+        sns.heatmap(
+            monthly_ret.fillna(0) * 100.0,
+            annot=True,
+            fmt="0.1f",
+            annot_kws={"size": 8},
+            alpha=1.0,
+            center=0.0,
+            cbar=False,
+            cmap=cm.RdYlGn,
+            ax=ax, **kwargs)
+        ax.set_title('Monthly Returns (%)', fontweight='bold')
+        ax.set_ylabel('')
+        ax.set_yticklabels(ax.get_yticklabels(), rotation=0)
+        ax.set_xlabel('')
+
+        return ax
+
+
+    def _plot_yearly_returns(self, returns, ax=None, **kwargs):
+        """
+        Plots a barplot of returns by year.
+        """
+        def format_perc(x, pos): return '%.0f%%' % x
+
+        if ax is None:
+            ax = plt.gca()
+
+        y_axis_formatter = FuncFormatter(format_perc)
+        ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))
+
+        yly_ret = perf.aggregate_returns(returns, 'yearly') * 100.0
+        yly_ret.plot(ax=ax, kind="bar")
+        ax.set_title('Yearly Returns (%)', fontweight='bold')
+        ax.set_ylabel('')
+        ax.set_xlabel('')
+        ax.set_xticklabels(ax.get_xticklabels(), rotation=45)
+
+        return ax
+
+
+    def _plot_txt_curve(self, returns, cum_returns, positions, benchmark_returns,
+                       ax=None, **kwargs):
+        """
+        Outputs the statistics for the equity curve.
+        """
+        def format_perc(x, pos): return '%.0f%%' % x
+
+        if ax is None:
+            ax = plt.gca()
+
+        y_axis_formatter = FuncFormatter(format_perc)
+        ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))
+
+#        equity_b = cum_returns(returns_b, starting_value=1.0)
+        tot_ret = cum_returns[-1] - 1.0
+#        tot_ret_b = equity_b[-1] - 1.0
+        cagr = perf.create_cagr(cum_returns)
+#        cagr_b = perf.create_cagr(equity_b)
+        sharpe = perf.create_sharpe_ratio(returns)
+#        sharpe_b = perf.create_sharpe_ratio(returns_b)
+        sortino = perf.create_sortino_ratio(returns)
+#        sortino_b = perf.create_sortino_ratio(returns_b)
+        rsq = perf.rsquared(range(cum_returns.shape[0]), cum_returns)
+#        rsq_b = perf.rsquared(range(equity_b.shape[0]), equity_b)
+        dd, dd_max, dd_dur = perf.create_drawdowns(cum_returns)
+#        dd_b, dd_max_b, dd_dur_b = perf.create_drawdowns(equity_b)
+        trd_yr = positions.shape[0] / ((returns.index[-1] - returns.index[0]).days / 365.0)
+
+        ax.text(0.25, 8.9, 'Total Return', fontsize=8)
+        ax.text(7.50, 8.9, '{:.0%}'.format(tot_ret), fontweight='bold', horizontalalignment='right', fontsize=8)
+#        ax.text(9.75, 8.9, '{:.0%}'.format(tot_ret_b), fontweight='bold', horizontalalignment='right', fontsize=8)
+
+        ax.text(0.25, 7.9, 'CAGR', fontsize=8)
+        ax.text(7.50, 7.9, '{:.2%}'.format(cagr), fontweight='bold', horizontalalignment='right', fontsize=8)
+#        ax.text(9.75, 7.9, '{:.2%}'.format(cagr_b), fontweight='bold', horizontalalignment='right', fontsize=8)
+
+        ax.text(0.25, 6.9, 'Sharpe Ratio', fontsize=8)
+        ax.text(7.50, 6.9, '{:.2f}'.format(sharpe), fontweight='bold', horizontalalignment='right', fontsize=8)
+#        ax.text(9.75, 6.9, '{:.2f}'.format(sharpe_b), fontweight='bold', horizontalalignment='right', fontsize=8)
+
+        ax.text(0.25, 5.9, 'Sortino Ratio', fontsize=8)
+        ax.text(7.50, 5.9, '{:.2f}'.format(sortino), fontweight='bold', horizontalalignment='right', fontsize=8)
+#        ax.text(9.75, 5.9, '{:.2f}'.format(sortino_b), fontweight='bold', horizontalalignment='right', fontsize=8)
+
+        ax.text(0.25, 4.9, 'Annual Volatility', fontsize=8)
+        ax.text(7.50, 4.9, '{:.2%}'.format(returns.std() * np.sqrt(252)), fontweight='bold', horizontalalignment='right', fontsize=8)
+#        ax.text(9.75, 4.9, '{:.2%}'.format(returns_b.std() * np.sqrt(252)), fontweight='bold', horizontalalignment='right', fontsize=8)
+
+        ax.text(0.25, 3.9, 'R-Squared', fontsize=8)
+        ax.text(7.50, 3.9, '{:.2f}'.format(rsq), fontweight='bold', horizontalalignment='right', fontsize=8)
+#        ax.text(9.75, 3.9, '{:.2f}'.format(rsq_b), fontweight='bold', horizontalalignment='right', fontsize=8)
+
+        ax.text(0.25, 2.9, 'Max Daily Drawdown', fontsize=8)
+        ax.text(7.50, 2.9, '{:.2%}'.format(dd_max), color='red', fontweight='bold', horizontalalignment='right', fontsize=8)
+#        ax.text(9.75, 2.9, '{:.2%}'.format(dd_max_b), color='red', fontweight='bold', horizontalalignment='right', fontsize=8)
+
+        ax.text(0.25, 1.9, 'Max Drawdown Duration', fontsize=8)
+        ax.text(7.50, 1.9, '{:.0f}'.format(dd_dur), fontweight='bold', horizontalalignment='right', fontsize=8)
+#        ax.text(9.75, 1.9, '{:.0f}'.format(dd_dur_b), fontweight='bold', horizontalalignment='right', fontsize=8)
+
+        ax.text(0.25, 0.9, 'Trades per Year', fontsize=8)
+        ax.text(7.50, 0.9, '{:.1f}'.format(trd_yr), fontweight='bold', horizontalalignment='right', fontsize=8)
+
+        ax.set_title('Curve vs. Benchmark', fontweight='bold')
+        ax.grid(False)
+        ax.spines['top'].set_linewidth(2.0)
+        ax.spines['bottom'].set_linewidth(2.0)
+        ax.spines['right'].set_visible(False)
+        ax.spines['left'].set_visible(False)
+        ax.get_yaxis().set_visible(False)
+        ax.get_xaxis().set_visible(False)
+        ax.set_ylabel('')
+        ax.set_xlabel('')
+
+        ax.axis([0, 10, 0, 10])
+        return ax
+
+
+    def plot_results(self):
+        """
+        Plot the Tearsheet
+        """
+        rc = {'lines.linewidth': 1.0,
+              'axes.facecolor': '0.995',
+              'figure.facecolor': '0.97',
+              'font.family': 'serif',
+              'font.serif': 'Ubuntu',
+              'font.monospace': 'Ubuntu Mono',
+              'font.size': 10,
+              'axes.labelsize': 10,
+              'axes.labelweight': 'bold',
+              'axes.titlesize': 10,
+              'xtick.labelsize': 8,
+              'ytick.labelsize': 8,
+              'legend.fontsize': 10,
+              'figure.titlesize': 12
+        }
+        sns.set_context(rc)
+        sns.set_style("whitegrid")
+        sns.set_palette("deep", desat=.6)
+
+        vertical_sections = 5
+        fig = plt.figure(figsize=(10, vertical_sections * 3))
+        fig.suptitle(self.title, y=0.96)
+        gs = gridspec.GridSpec(vertical_sections, 3, wspace=0.25, hspace=0.5)
+
+        stats = self.get_results()
+        positions = self._get_positions()
+
+        ax_equity = plt.subplot(gs[:2, :])
+        ax_drawdown = plt.subplot(gs[2, :], sharex=ax_equity)
+        ax_monthly_returns = plt.subplot(gs[3, :2])
+        ax_yearly_returns = plt.subplot(gs[3, 2])
+        ax_txt_curve = plt.subplot(gs[4, 0])
+        ax_txt_trade = plt.subplot(gs[4, 1])
+        ax_txt_time = plt.subplot(gs[4, 2])
+
+        self._plot_equity(stats['cum_returns'], ax=ax_equity)
+        self._plot_drawdown(stats['drawdowns'], ax=ax_drawdown)
+        self._plot_monthly_returns(stats['returns'], ax=ax_monthly_returns)
+        self._plot_yearly_returns(stats['returns'], ax=ax_yearly_returns)
+        self._plot_txt_curve(stats["returns"], stats['cum_returns'],
+                             self._get_positions(), None, ax=ax_txt_curve)
+#        self._plot_txt_trade(positions, ax=ax_txt_trade)
+#        self._plot_txt_time(equity["Returns"], ax=ax_txt_time)
+
+        # Plot the figure
+        plt.show()
+
+
+    def get_filename(self, filename=""):
+        if filename == "":
+            now = datetime.utcnow()
+            filename = "statistics_" + now.strftime("%Y-%m-%d_%H%M%S") + ".pkl"
+            filename = os.path.expanduser(os.path.join(self.config.OUTPUT_DIR, filename))
+        return filename
+
+    def save(self, filename=""):
+        filename = self.get_filename(filename)
+        #print("Save results to '%s'" % filename)
+        #with open(filename, 'wb') as fd:
+        #    pickle.dump(self, fd)

--- a/qstrader/statistics/tearsheet.py
+++ b/qstrader/statistics/tearsheet.py
@@ -1,15 +1,11 @@
 from .base import AbstractStatistics
-from ..compat import pickle
 from ..price_parser import PriceParser
 
-from datetime import datetime
 from matplotlib.ticker import FuncFormatter
 from matplotlib import cm
 
 import qstrader.statistics.performance as perf
 
-import os
-import math
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
@@ -27,21 +23,24 @@ class TearsheetStatistics(AbstractStatistics):
         """
         self.config = config
         self.portfolio_handler = portfolio_handler
+        self.price_handler = portfolio_handler.price_handler
         self.title = '\n'.join(title)
         self.benchmark = benchmark
         self.equity = {}
         self.equity_benchmark = {}
         self.log_scale = False
 
-
     def update(self, timestamp, portfolio_handler):
         """
-        Update all statistics that must be tracked over time.
+        Update equity curve and benchmark equity curve that must be tracked
+        over time.
         """
         self.equity[timestamp] = PriceParser.display(
-            portfolio_handler.portfolio.equity
+            self.portfolio_handler.portfolio.equity
         )
-
+        self.equity_benchmark[timestamp] = PriceParser.display(
+            self.price_handler.get_last_close(self.benchmark)
+        )
 
     def get_results(self):
         """
@@ -60,30 +59,49 @@ class TearsheetStatistics(AbstractStatistics):
         dd_s, max_dd, dd_dur = perf.create_drawdowns(cum_returns_s)
 
         statistics = {}
+
+        # Equity statistics
         statistics["sharpe"] = perf.create_sharpe_ratio(returns_s)
         statistics["drawdowns"] = dd_s
-        statistics["max_drawdown"] = max_dd  #TODO: is DD amt really needed?
+        # TODO: need to have max_drawdown so it can be printed at end of test
+        statistics["max_drawdown"] = max_dd
         statistics["max_drawdown_pct"] = max_dd
         statistics["max_drawdown_duration"] = dd_dur
         statistics["equity"] = equity_s
         statistics["returns"] = returns_s
         statistics["cum_returns"] = cum_returns_s
+        statistics["positions"] = self._get_positions()
+
+        # Benchmark statistics if benchmark ticker specified
+        if self.benchmark is not None:
+            equity_b = pd.Series(self.equity_benchmark).sort_index()
+            returns_b = equity_b.pct_change().fillna(0.0)
+            cum_returns_b = np.exp(np.log(1 + returns_b).cumsum())
+            dd_b, max_dd_b, dd_dur_b = perf.create_drawdowns(cum_returns_b)
+            statistics["sharpe_b"] = perf.create_sharpe_ratio(returns_b)
+            statistics["drawdowns_b"] = dd_b
+            statistics["max_drawdown_pct_b"] = max_dd_b
+            statistics["max_drawdown_duration_b"] = dd_dur_b
+            statistics["equity_b"] = equity_b
+            statistics["returns_b"] = returns_b
+            statistics["cum_returns_b"] = cum_returns_b
 
         return statistics
-
 
     def _get_positions(self):
         """
         Retrieve the list of closed Positions objects from the portfolio
         and reformat into a pandas dataframe to be returned
         """
+        def x(p):
+            return PriceParser.display(p)
+
         pos = self.portfolio_handler.portfolio.closed_positions
         a = []
         for p in pos:
             a.append(p.__dict__)
 
         df = pd.DataFrame(a)
-        x = lambda x: PriceParser.display(x)
 
         df['avg_bot'] = df['avg_bot'].apply(x)
         df['avg_price'] = df['avg_price'].apply(x)
@@ -101,14 +119,19 @@ class TearsheetStatistics(AbstractStatistics):
         df['total_sld'] = df['total_sld'].apply(x)
         df['unrealised_pnl'] = df['unrealised_pnl'].apply(x)
 
+        df['trade_pct'] = (df['avg_sld'] / df['avg_bot'] - 1.0)
+
         return df
 
-
-    def _plot_equity(self, equity, benchmark=None, ax=None, **kwargs):
+    def _plot_equity(self, stats, ax=None, **kwargs):
         """
         Plots cumulative rolling returns versus some benchmark.
         """
-        def format_two_dec(x, pos): return '%.2f' % x
+        def format_two_dec(x, pos):
+            return '%.2f' % x
+
+        equity = stats['cum_returns']
+        benchmark = stats['cum_returns_b']
 
         if ax is None:
             ax = plt.gca()
@@ -119,12 +142,11 @@ class TearsheetStatistics(AbstractStatistics):
         ax.xaxis.set_major_locator(mdates.YearLocator(1))
         ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))
 
-        """
-        if benchmark is not None:
+        if self.benchmark is not None:
             benchmark.plot(
-                lw=2, color='gray', label='S&P500', alpha=0.60, ax=ax, **kwargs
+                lw=2, color='gray', label=self.benchmark, alpha=0.60,
+                ax=ax, **kwargs
             )
-        """
 
         equity.plot(lw=2, color='green', alpha=0.6, x_compat=False,
                     label='Backtest', ax=ax, **kwargs)
@@ -139,12 +161,14 @@ class TearsheetStatistics(AbstractStatistics):
 
         return ax
 
-
-    def _plot_drawdown(self, drawdown, ax=None, **kwargs):
+    def _plot_drawdown(self, stats, ax=None, **kwargs):
         """
         Plots the underwater curve
         """
-        def format_perc(x, pos): return '%.0f%%' % x
+        def format_perc(x, pos):
+            return '%.0f%%' % x
+
+        drawdown = stats['drawdowns']
 
         if ax is None:
             ax = plt.gca()
@@ -159,21 +183,22 @@ class TearsheetStatistics(AbstractStatistics):
         ax.set_title('Drawdown (%)', fontweight='bold')
         return ax
 
-
-    def _plot_monthly_returns(self, returns, ax=None, **kwargs):
+    def _plot_monthly_returns(self, stats, ax=None, **kwargs):
         """
         Plots a heatmap of the monthly returns.
         """
+        returns = stats['returns']
         if ax is None:
             ax = plt.gca()
 
         monthly_ret = perf.aggregate_returns(returns, 'monthly')
         monthly_ret = monthly_ret.unstack()
         monthly_ret = np.round(monthly_ret, 3)
-        monthly_ret.rename(columns={1: 'Jan', 2: 'Feb', 3: 'Mar', 4: 'Apr',
-                                    5: 'May', 6: 'Jun', 7: 'Jul', 8: 'Aug',
-                                    9: 'Sep', 10: 'Oct', 11: 'Nov', 12: 'Dec'},
-                                    inplace=True
+        monthly_ret.rename(
+            columns={1: 'Jan', 2: 'Feb', 3: 'Mar', 4: 'Apr',
+                     5: 'May', 6: 'Jun', 7: 'Jul', 8: 'Aug',
+                     9: 'Sep', 10: 'Oct', 11: 'Nov', 12: 'Dec'},
+            inplace=True
         )
 
         sns.heatmap(
@@ -193,12 +218,14 @@ class TearsheetStatistics(AbstractStatistics):
 
         return ax
 
-
-    def _plot_yearly_returns(self, returns, ax=None, **kwargs):
+    def _plot_yearly_returns(self, stats, ax=None, **kwargs):
         """
         Plots a barplot of returns by year.
         """
-        def format_perc(x, pos): return '%.0f%%' % x
+        def format_perc(x, pos):
+            return '%.0f%%' % x
+
+        returns = stats['returns']
 
         if ax is None:
             ax = plt.gca()
@@ -215,13 +242,16 @@ class TearsheetStatistics(AbstractStatistics):
 
         return ax
 
-
-    def _plot_txt_curve(self, returns, cum_returns, positions, benchmark_returns,
-                       ax=None, **kwargs):
+    def _plot_txt_curve(self, stats, ax=None, **kwargs):
         """
         Outputs the statistics for the equity curve.
         """
-        def format_perc(x, pos): return '%.0f%%' % x
+        def format_perc(x, pos):
+            return '%.0f%%' % x
+
+        returns = stats["returns"]
+        cum_returns = stats['cum_returns']
+        positions = stats['positions']
 
         if ax is None:
             ax = plt.gca()
@@ -229,57 +259,63 @@ class TearsheetStatistics(AbstractStatistics):
         y_axis_formatter = FuncFormatter(format_perc)
         ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))
 
-#        equity_b = cum_returns(returns_b, starting_value=1.0)
         tot_ret = cum_returns[-1] - 1.0
-#        tot_ret_b = equity_b[-1] - 1.0
         cagr = perf.create_cagr(cum_returns)
-#        cagr_b = perf.create_cagr(equity_b)
         sharpe = perf.create_sharpe_ratio(returns)
-#        sharpe_b = perf.create_sharpe_ratio(returns_b)
         sortino = perf.create_sortino_ratio(returns)
-#        sortino_b = perf.create_sortino_ratio(returns_b)
         rsq = perf.rsquared(range(cum_returns.shape[0]), cum_returns)
-#        rsq_b = perf.rsquared(range(equity_b.shape[0]), equity_b)
         dd, dd_max, dd_dur = perf.create_drawdowns(cum_returns)
-#        dd_b, dd_max_b, dd_dur_b = perf.create_drawdowns(equity_b)
         trd_yr = positions.shape[0] / ((returns.index[-1] - returns.index[0]).days / 365.0)
 
         ax.text(0.25, 8.9, 'Total Return', fontsize=8)
         ax.text(7.50, 8.9, '{:.0%}'.format(tot_ret), fontweight='bold', horizontalalignment='right', fontsize=8)
-#        ax.text(9.75, 8.9, '{:.0%}'.format(tot_ret_b), fontweight='bold', horizontalalignment='right', fontsize=8)
 
         ax.text(0.25, 7.9, 'CAGR', fontsize=8)
         ax.text(7.50, 7.9, '{:.2%}'.format(cagr), fontweight='bold', horizontalalignment='right', fontsize=8)
-#        ax.text(9.75, 7.9, '{:.2%}'.format(cagr_b), fontweight='bold', horizontalalignment='right', fontsize=8)
 
         ax.text(0.25, 6.9, 'Sharpe Ratio', fontsize=8)
         ax.text(7.50, 6.9, '{:.2f}'.format(sharpe), fontweight='bold', horizontalalignment='right', fontsize=8)
-#        ax.text(9.75, 6.9, '{:.2f}'.format(sharpe_b), fontweight='bold', horizontalalignment='right', fontsize=8)
 
         ax.text(0.25, 5.9, 'Sortino Ratio', fontsize=8)
         ax.text(7.50, 5.9, '{:.2f}'.format(sortino), fontweight='bold', horizontalalignment='right', fontsize=8)
-#        ax.text(9.75, 5.9, '{:.2f}'.format(sortino_b), fontweight='bold', horizontalalignment='right', fontsize=8)
 
         ax.text(0.25, 4.9, 'Annual Volatility', fontsize=8)
         ax.text(7.50, 4.9, '{:.2%}'.format(returns.std() * np.sqrt(252)), fontweight='bold', horizontalalignment='right', fontsize=8)
-#        ax.text(9.75, 4.9, '{:.2%}'.format(returns_b.std() * np.sqrt(252)), fontweight='bold', horizontalalignment='right', fontsize=8)
 
         ax.text(0.25, 3.9, 'R-Squared', fontsize=8)
         ax.text(7.50, 3.9, '{:.2f}'.format(rsq), fontweight='bold', horizontalalignment='right', fontsize=8)
-#        ax.text(9.75, 3.9, '{:.2f}'.format(rsq_b), fontweight='bold', horizontalalignment='right', fontsize=8)
 
         ax.text(0.25, 2.9, 'Max Daily Drawdown', fontsize=8)
         ax.text(7.50, 2.9, '{:.2%}'.format(dd_max), color='red', fontweight='bold', horizontalalignment='right', fontsize=8)
-#        ax.text(9.75, 2.9, '{:.2%}'.format(dd_max_b), color='red', fontweight='bold', horizontalalignment='right', fontsize=8)
 
         ax.text(0.25, 1.9, 'Max Drawdown Duration', fontsize=8)
         ax.text(7.50, 1.9, '{:.0f}'.format(dd_dur), fontweight='bold', horizontalalignment='right', fontsize=8)
-#        ax.text(9.75, 1.9, '{:.0f}'.format(dd_dur_b), fontweight='bold', horizontalalignment='right', fontsize=8)
 
         ax.text(0.25, 0.9, 'Trades per Year', fontsize=8)
         ax.text(7.50, 0.9, '{:.1f}'.format(trd_yr), fontweight='bold', horizontalalignment='right', fontsize=8)
+        ax.set_title('Curve', fontweight='bold')
 
-        ax.set_title('Curve vs. Benchmark', fontweight='bold')
+        if self.benchmark is not None:
+            returns_b = stats['returns_b']
+            equity_b = stats['cum_returns_b']
+            tot_ret_b = equity_b[-1] - 1.0
+            cagr_b = perf.create_cagr(equity_b)
+            sharpe_b = perf.create_sharpe_ratio(returns_b)
+            sortino_b = perf.create_sortino_ratio(returns_b)
+            rsq_b = perf.rsquared(range(equity_b.shape[0]), equity_b)
+            dd_b, dd_max_b, dd_dur_b = perf.create_drawdowns(equity_b)
+
+            ax.text(9.75, 8.9, '{:.0%}'.format(tot_ret_b), fontweight='bold', horizontalalignment='right', fontsize=8)
+            ax.text(9.75, 7.9, '{:.2%}'.format(cagr_b), fontweight='bold', horizontalalignment='right', fontsize=8)
+            ax.text(9.75, 6.9, '{:.2f}'.format(sharpe_b), fontweight='bold', horizontalalignment='right', fontsize=8)
+            ax.text(9.75, 5.9, '{:.2f}'.format(sortino_b), fontweight='bold', horizontalalignment='right', fontsize=8)
+            ax.text(9.75, 4.9, '{:.2%}'.format(returns_b.std() * np.sqrt(252)), fontweight='bold', horizontalalignment='right', fontsize=8)
+            ax.text(9.75, 3.9, '{:.2f}'.format(rsq_b), fontweight='bold', horizontalalignment='right', fontsize=8)
+            ax.text(9.75, 2.9, '{:.2%}'.format(dd_max_b), color='red', fontweight='bold', horizontalalignment='right', fontsize=8)
+            ax.text(9.75, 1.9, '{:.0f}'.format(dd_dur_b), fontweight='bold', horizontalalignment='right', fontsize=8)
+
+            ax.set_title('Curve vs. Benchmark', fontweight='bold')
+
         ax.grid(False)
         ax.spines['top'].set_linewidth(2.0)
         ax.spines['bottom'].set_linewidth(2.0)
@@ -293,25 +329,174 @@ class TearsheetStatistics(AbstractStatistics):
         ax.axis([0, 10, 0, 10])
         return ax
 
+    def _plot_txt_trade(self, stats, ax=None, **kwargs):
+        """
+        Outputs the statistics for the trades.
+        """
+        def format_perc(x, pos):
+            return '%.0f%%' % x
+
+        if ax is None:
+            ax = plt.gca()
+
+        pos = stats['positions']
+
+        y_axis_formatter = FuncFormatter(format_perc)
+        ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))
+
+        num_trades = pos.shape[0]
+        win_pct = pos[pos["trade_pct"] > 0].shape[0] / float(num_trades)
+        win_pct_str = '{:.0%}'.format(win_pct)
+        avg_trd_pct = '{:.2%}'.format(np.mean(pos["trade_pct"]))
+        avg_win_pct = '{:.2%}'.format(np.mean(pos[pos["trade_pct"] > 0]["trade_pct"]))
+        avg_loss_pct = '{:.2%}'.format(np.mean(pos[pos["trade_pct"] <= 0]["trade_pct"]))
+        max_win_pct = '{:.2%}'.format(np.max(pos["trade_pct"]))
+        max_loss_pct = '{:.2%}'.format(np.min(pos["trade_pct"]))
+        max_loss_dt = ''  # pos[pos["trade_pct"] == np.min(pos["trade_pct"])].entry_date.values[0]
+        avg_dit = '0.0'  # = '{:.2f}'.format(np.mean(pos.time_in_pos))
+
+        ax.text(0.5, 8.9, 'Trade Winning %', fontsize=8)
+        ax.text(9.5, 8.9, win_pct_str, fontsize=8, fontweight='bold', horizontalalignment='right')
+
+        ax.text(0.5, 7.9, 'Average Trade %', fontsize=8)
+        ax.text(9.5, 7.9, avg_trd_pct, fontsize=8, fontweight='bold', horizontalalignment='right')
+
+        ax.text(0.5, 6.9, 'Average Win %', fontsize=8)
+        ax.text(9.5, 6.9, avg_win_pct, fontsize=8, fontweight='bold', color='green', horizontalalignment='right')
+
+        ax.text(0.5, 5.9, 'Average Loss %', fontsize=8)
+        ax.text(9.5, 5.9, avg_loss_pct, fontsize=8, fontweight='bold', color='red', horizontalalignment='right')
+
+        ax.text(0.5, 4.9, 'Best Trade %', fontsize=8)
+        ax.text(9.5, 4.9, max_win_pct, fontsize=8, fontweight='bold', color='green', horizontalalignment='right')
+
+        ax.text(0.5, 3.9, 'Worst Trade %', fontsize=8)
+        ax.text(9.5, 3.9, max_loss_pct, color='red', fontsize=8, fontweight='bold', horizontalalignment='right')
+
+        ax.text(0.5, 2.9, 'Worst Trade Date', fontsize=8)
+        ax.text(9.5, 2.9, max_loss_dt, fontsize=8, fontweight='bold', horizontalalignment='right')
+
+        ax.text(0.5, 1.9, 'Avg Days in Trade', fontsize=8)
+        ax.text(9.5, 1.9, avg_dit, fontsize=8, fontweight='bold', horizontalalignment='right')
+
+        ax.text(0.5, 0.9, 'Trades', fontsize=8)
+        ax.text(9.5, 0.9, num_trades, fontsize=8, fontweight='bold', horizontalalignment='right')
+
+        ax.set_title('Trade', fontweight='bold')
+        ax.grid(False)
+        ax.spines['top'].set_linewidth(2.0)
+        ax.spines['bottom'].set_linewidth(2.0)
+        ax.spines['right'].set_visible(False)
+        ax.spines['left'].set_visible(False)
+        ax.get_yaxis().set_visible(False)
+        ax.get_xaxis().set_visible(False)
+        ax.set_ylabel('')
+        ax.set_xlabel('')
+
+        ax.axis([0, 10, 0, 10])
+        return ax
+
+    def _plot_txt_time(self, stats, ax=None, **kwargs):
+        """
+        Outputs the statistics for various time frames.
+        """
+        def format_perc(x, pos):
+            return '%.0f%%' % x
+
+        returns = stats['returns']
+
+        if ax is None:
+            ax = plt.gca()
+
+        y_axis_formatter = FuncFormatter(format_perc)
+        ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))
+
+        mly_ret = perf.aggregate_returns(returns, 'monthly')
+        yly_ret = perf.aggregate_returns(returns, 'yearly')
+
+        mly_pct = mly_ret[mly_ret >= 0].shape[0] / float(mly_ret.shape[0])
+        mly_avg_win_pct = np.mean(mly_ret[mly_ret >= 0])
+        mly_avg_loss_pct = np.mean(mly_ret[mly_ret < 0])
+        mly_max_win_pct = np.max(mly_ret)
+        mly_max_loss_pct = np.min(mly_ret)
+        yly_pct = yly_ret[yly_ret >= 0].shape[0] / float(yly_ret.shape[0])
+        yly_max_win_pct = np.max(yly_ret)
+        yly_max_loss_pct = np.min(yly_ret)
+
+        ax.text(0.5, 8.9, 'Winning Months %', fontsize=8)
+        ax.text(9.5, 8.9, '{:.0%}'.format(mly_pct), fontsize=8, fontweight='bold',
+                horizontalalignment='right')
+
+        ax.text(0.5, 7.9, 'Average Winning Month %', fontsize=8)
+        ax.text(9.5, 7.9, '{:.2%}'.format(mly_avg_win_pct), fontsize=8, fontweight='bold',
+                color='red' if mly_avg_win_pct < 0 else 'green',
+                horizontalalignment='right')
+
+        ax.text(0.5, 6.9, 'Average Losing Month %', fontsize=8)
+        ax.text(9.5, 6.9, '{:.2%}'.format(mly_avg_loss_pct), fontsize=8, fontweight='bold',
+                color='red' if mly_avg_loss_pct < 0 else 'green',
+                horizontalalignment='right')
+
+        ax.text(0.5, 5.9, 'Best Month %', fontsize=8)
+        ax.text(9.5, 5.9, '{:.2%}'.format(mly_max_win_pct), fontsize=8, fontweight='bold',
+                color='red' if mly_max_win_pct < 0 else 'green',
+                horizontalalignment='right')
+
+        ax.text(0.5, 4.9, 'Worst Month %', fontsize=8)
+        ax.text(9.5, 4.9, '{:.2%}'.format(mly_max_loss_pct), fontsize=8, fontweight='bold',
+                color='red' if mly_max_loss_pct < 0 else 'green',
+                horizontalalignment='right')
+
+        ax.text(0.5, 3.9, 'Winning Years %', fontsize=8)
+        ax.text(9.5, 3.9, '{:.0%}'.format(yly_pct), fontsize=8, fontweight='bold',
+                horizontalalignment='right')
+
+        ax.text(0.5, 2.9, 'Best Year %', fontsize=8)
+        ax.text(9.5, 2.9, '{:.2%}'.format(yly_max_win_pct), fontsize=8,
+                fontweight='bold', color='red' if yly_max_win_pct < 0 else 'green',
+                horizontalalignment='right')
+
+        ax.text(0.5, 1.9, 'Worst Year %', fontsize=8)
+        ax.text(9.5, 1.9, '{:.2%}'.format(yly_max_loss_pct), fontsize=8,
+                fontweight='bold', color='red' if yly_max_loss_pct < 0 else 'green',
+                horizontalalignment='right')
+
+        # ax.text(0.5, 0.9, 'Positive 12 Month Periods', fontsize=8)
+        # ax.text(9.5, 0.9, num_trades, fontsize=8, fontweight='bold', horizontalalignment='right')
+
+        ax.set_title('Time', fontweight='bold')
+        ax.grid(False)
+        ax.spines['top'].set_linewidth(2.0)
+        ax.spines['bottom'].set_linewidth(2.0)
+        ax.spines['right'].set_visible(False)
+        ax.spines['left'].set_visible(False)
+        ax.get_yaxis().set_visible(False)
+        ax.get_xaxis().set_visible(False)
+        ax.set_ylabel('')
+        ax.set_xlabel('')
+
+        ax.axis([0, 10, 0, 10])
+        return ax
 
     def plot_results(self):
         """
         Plot the Tearsheet
         """
-        rc = {'lines.linewidth': 1.0,
-              'axes.facecolor': '0.995',
-              'figure.facecolor': '0.97',
-              'font.family': 'serif',
-              'font.serif': 'Ubuntu',
-              'font.monospace': 'Ubuntu Mono',
-              'font.size': 10,
-              'axes.labelsize': 10,
-              'axes.labelweight': 'bold',
-              'axes.titlesize': 10,
-              'xtick.labelsize': 8,
-              'ytick.labelsize': 8,
-              'legend.fontsize': 10,
-              'figure.titlesize': 12
+        rc = {
+            'lines.linewidth': 1.0,
+            'axes.facecolor': '0.995',
+            'figure.facecolor': '0.97',
+            'font.family': 'serif',
+            'font.serif': 'Ubuntu',
+            'font.monospace': 'Ubuntu Mono',
+            'font.size': 10,
+            'axes.labelsize': 10,
+            'axes.labelweight': 'bold',
+            'axes.titlesize': 10,
+            'xtick.labelsize': 8,
+            'ytick.labelsize': 8,
+            'legend.fontsize': 10,
+            'figure.titlesize': 12
         }
         sns.set_context(rc)
         sns.set_style("whitegrid")
@@ -323,7 +508,6 @@ class TearsheetStatistics(AbstractStatistics):
         gs = gridspec.GridSpec(vertical_sections, 3, wspace=0.25, hspace=0.5)
 
         stats = self.get_results()
-        positions = self._get_positions()
 
         ax_equity = plt.subplot(gs[:2, :])
         ax_drawdown = plt.subplot(gs[2, :], sharex=ax_equity)
@@ -333,28 +517,13 @@ class TearsheetStatistics(AbstractStatistics):
         ax_txt_trade = plt.subplot(gs[4, 1])
         ax_txt_time = plt.subplot(gs[4, 2])
 
-        self._plot_equity(stats['cum_returns'], ax=ax_equity)
-        self._plot_drawdown(stats['drawdowns'], ax=ax_drawdown)
-        self._plot_monthly_returns(stats['returns'], ax=ax_monthly_returns)
-        self._plot_yearly_returns(stats['returns'], ax=ax_yearly_returns)
-        self._plot_txt_curve(stats["returns"], stats['cum_returns'],
-                             self._get_positions(), None, ax=ax_txt_curve)
-#        self._plot_txt_trade(positions, ax=ax_txt_trade)
-#        self._plot_txt_time(equity["Returns"], ax=ax_txt_time)
+        self._plot_equity(stats, ax=ax_equity)
+        self._plot_drawdown(stats, ax=ax_drawdown)
+        self._plot_monthly_returns(stats, ax=ax_monthly_returns)
+        self._plot_yearly_returns(stats, ax=ax_yearly_returns)
+        self._plot_txt_curve(stats, ax=ax_txt_curve)
+        self._plot_txt_trade(stats, ax=ax_txt_trade)
+        self._plot_txt_time(stats, ax=ax_txt_time)
 
         # Plot the figure
         plt.show()
-
-
-    def get_filename(self, filename=""):
-        if filename == "":
-            now = datetime.utcnow()
-            filename = "statistics_" + now.strftime("%Y-%m-%d_%H%M%S") + ".pkl"
-            filename = os.path.expanduser(os.path.join(self.config.OUTPUT_DIR, filename))
-        return filename
-
-    def save(self, filename=""):
-        filename = self.get_filename(filename)
-        #print("Save results to '%s'" % filename)
-        #with open(filename, 'wb') as fd:
-        #    pickle.dump(self, fd)

--- a/qstrader/statistics/tearsheet.py
+++ b/qstrader/statistics/tearsheet.py
@@ -40,9 +40,10 @@ class TearsheetStatistics(AbstractStatistics):
         self.equity[timestamp] = PriceParser.display(
             self.portfolio_handler.portfolio.equity
         )
-        self.equity_benchmark[timestamp] = PriceParser.display(
-            self.price_handler.get_last_close(self.benchmark)
-        )
+        if self.benchmark is not None:
+            self.equity_benchmark[timestamp] = PriceParser.display(
+                self.price_handler.get_last_close(self.benchmark)
+            )
 
     def get_results(self):
         """
@@ -133,7 +134,6 @@ class TearsheetStatistics(AbstractStatistics):
             return '%.2f' % x
 
         equity = stats['cum_returns']
-        benchmark = stats['cum_returns_b']
 
         if ax is None:
             ax = plt.gca()
@@ -145,6 +145,7 @@ class TearsheetStatistics(AbstractStatistics):
         ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))
 
         if self.benchmark is not None:
+            benchmark = stats['cum_returns_b']
             benchmark.plot(
                 lw=2, color='gray', label=self.benchmark, alpha=0.60,
                 ax=ax, **kwargs


### PR DESCRIPTION
First version of the `Tearsheet` statistics class with an example mac_backtest_tearsheet.py.  Currently only bars supported until we can figure out a common interface to `Bars` and `Ticks` (i.e. add `get_last_price()` method to both)

Missing some trade statistics because we don't have position entry/exit dates, # bars in trade, etc.

Comments?

Closes https://github.com/mhallsmoore/qstrader/issues/90
