### PR TITLE
PriceParser should now deal with np.int64 being displayed

### DIFF
--- a/qstrader/price_parser.py
+++ b/qstrader/price_parser.py
@@ -1,8 +1,6 @@
 from __future__ import division
 from multipledispatch import dispatch
-import six
-
-int_t = six.integer_types
+import numpy as np
 
 
 class PriceParser(object):
@@ -22,8 +20,15 @@ class PriceParser(object):
     # 10,000,000
     PRICE_MULTIPLIER = 10000000
 
+    """Parse Methods. Multiplies a float out into an int if needed."""
+
     @staticmethod
-    @dispatch(int_t)
+    @dispatch(int)
+    def parse(x):  # flake8: noqa
+        return x
+
+    @staticmethod
+    @dispatch(np.int64)
     def parse(x):  # flake8: noqa
         return x
 
@@ -37,8 +42,15 @@ class PriceParser(object):
     def parse(x):  # flake8: noqa
         return int(x * PriceParser.PRICE_MULTIPLIER)
 
+    """Display Methods. Multiplies a float out into an int if needed."""
+
     @staticmethod
-    @dispatch(int_t)
+    @dispatch(int)
+    def display(x):  # flake8: noqa
+        return round(x / PriceParser.PRICE_MULTIPLIER, 2)
+
+    @staticmethod
+    @dispatch(np.int64)
     def display(x):  # flake8: noqa
         return round(x / PriceParser.PRICE_MULTIPLIER, 2)
 
@@ -48,11 +60,11 @@ class PriceParser(object):
         return round(x, 2)
 
     @staticmethod
-    @dispatch(int_t, int_t)
+    @dispatch(int, int)
     def display(x, dp):  # flake8: noqa
         return round(x / PriceParser.PRICE_MULTIPLIER, dp)
 
     @staticmethod
-    @dispatch(float, int_t)
+    @dispatch(float, int)
     def display(x, dp):  # flake8: noqa
         return round(x, dp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ pytz==2015.7
 requests_cache==0.4.12
 scipy==0.17.0
 simplegeneric==0.8.1
-six==1.10.0
 traitlets==4.1.0
 seaborn>=0.7.0
 click>=6.6


### PR DESCRIPTION
@mhallsmoore Try and rebuild https://github.com/mhallsmoore/qstrader/pull/129 once this is merged into master.

Tests are fine without six.integer_types so I've removed. We've got a truckload of dependancies, so happy to remove where we can 