### PR TITLE
Open short position has incorrect market_value, unrealized and realized pnl

### DIFF
--- a/qstrader/position.py
+++ b/qstrader/position.py
@@ -1,3 +1,6 @@
+from numpy import sign
+
+
 class Position(object):
     def __init__(
         self, action, ticker, init_quantity,
@@ -70,7 +73,7 @@ class Position(object):
         and loss of any transactions.
         """
         midpoint = (bid + ask) // 2
-        self.market_value = self.quantity * midpoint
+        self.market_value = self.quantity * midpoint * sign(self.net)
         self.unrealised_pnl = self.market_value - self.cost_basis
         self.realised_pnl = self.market_value + self.net_incl_comm
 

--- a/tests/test_position.py
+++ b/tests/test_position.py
@@ -154,7 +154,7 @@ class TestShortPosition(unittest.TestCase):
         self.assertEqual(PriceParser.display(self.position.cost_basis), -7768.00)
         self.assertEqual(PriceParser.display(self.position.market_value), -7769.00)
         self.assertEqual(PriceParser.display(self.position.unrealised_pnl), -1.00)
-        self.assertEqual(PriceParser.display(self.position.realised_pnl), 0.0)
+        self.assertEqual(PriceParser.display(self.position.realised_pnl), -1.0)
 
         self.position.update_market_value(
             PriceParser.parse(77.72), PriceParser.parse(77.72)
@@ -163,7 +163,7 @@ class TestShortPosition(unittest.TestCase):
         self.assertEqual(PriceParser.display(self.position.cost_basis), -7768.00)
         self.assertEqual(PriceParser.display(self.position.market_value), -7772.00)
         self.assertEqual(PriceParser.display(self.position.unrealised_pnl), -4.00)
-        self.assertEqual(PriceParser.display(self.position.realised_pnl), 0.0)
+        self.assertEqual(PriceParser.display(self.position.realised_pnl), -4.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_position.py
+++ b/tests/test_position.py
@@ -137,5 +137,34 @@ class TestRoundTripPGPosition(unittest.TestCase):
         self.assertEqual(PriceParser.display(self.position.realised_pnl), -19.50)
 
 
+class TestShortPosition(unittest.TestCase):
+    """
+    Test a short position in Proctor & Gamble where the initial
+    trade is a sell/short of 100 shares of PG, at a price of
+    $77.69, with $1.00 commission.
+    """
+    def setUp(self):
+        self.position = Position(
+            "SLD", "PG", 100,
+            PriceParser.parse(77.69), PriceParser.parse(1.00),
+            PriceParser.parse(77.68), PriceParser.parse(77.70)
+        )
+
+    def test_open_short_position(self):
+        self.assertEqual(PriceParser.display(self.position.cost_basis), -7768.00)
+        self.assertEqual(PriceParser.display(self.position.market_value), -7769.00)
+        self.assertEqual(PriceParser.display(self.position.unrealised_pnl), -1.00)
+        self.assertEqual(PriceParser.display(self.position.realised_pnl), 0.0)
+
+        self.position.update_market_value(
+            PriceParser.parse(77.72), PriceParser.parse(77.72)
+        )
+
+        self.assertEqual(PriceParser.display(self.position.cost_basis), -7768.00)
+        self.assertEqual(PriceParser.display(self.position.market_value), -7772.00)
+        self.assertEqual(PriceParser.display(self.position.unrealised_pnl), -4.00)
+        self.assertEqual(PriceParser.display(self.position.realised_pnl), 0.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When short position is open, the calculation of market_value does not look correct.  That affects the calculation of unrealized and realized pnl and subsequently portfolio equity.  I created a test to show the issue.