### PR TITLE
Ib integration

### DIFF
--- a/qstrader/price_handler/ib_bar.py
+++ b/qstrader/price_handler/ib_bar.py
@@ -1,0 +1,75 @@
+import os
+import datetime
+from .base import AbstractBarPriceHandler
+
+from ibapi.client import EClient
+from ibapi.wrapper import EWrapper
+from ibapi.contract import *
+
+import logging
+
+class IBClient(EClient):
+    def __init__(self, wrapper):
+        EClient.__init__(self, wrapper)
+
+
+class IBWrapper(EWrapper):
+    def __init__(self):
+        EWrapper.__init__(self)
+
+    def historicalData(self, reqId:int, date:str, open:float, high:float,
+                        low: float, close:float, volume: int, barCount: int,
+                        WAP:float, hasGaps: int):
+        logging.error("RECEIVED HISTORICAL DATA BAR.")
+
+
+class IBBarPriceHandler(AbstractBarPriceHandler, IBWrapper, IBClient):
+    """
+    Designed to feed either live or historic market data bars
+    from an Interactive Brokers connection.
+
+    Each "IB-connected" module requires its 'client' and 'wrapper' methods.
+
+    TODO:
+        * Historic/Live mode to be set by whether QSTrader is in Backtest or Live mode
+    """
+    def __init__(
+        self, events_queue, tickers, settings, mode="historic",
+        hist_end_date = datetime.datetime.now() - datetime.timedelta(days=3),
+        hist_duration="1 D", hist_barsize="1 min"
+    ):
+        logging.basicConfig( level=logging.ERROR )
+
+        self.ib_wrapper = IBWrapper()
+        self.ib_client = IBClient(self.ib_wrapper)
+
+        self.ib_client.connect("127.0.0.1",4001,0)
+
+        self.tickers = {}
+        self.mode = mode
+        self.continue_backtest = True
+        self.hist_end_date = hist_end_date
+        self.hist_duration = hist_duration
+        self.hist_barsize = hist_barsize
+
+        for ticker in tickers:
+            self._subscribe_ticker(ticker)
+
+        import time
+        time.sleep(10)
+
+
+    def _subscribe_ticker(self, ticker):
+        if ticker not in self.tickers:
+            # Set up an IB ContractS
+            contract = Contract()
+            contract.exchange = "SMART"
+            contract.symbol = ticker
+            contract.secType = "STK"
+            contract.currency = "USD"
+
+        if self.mode == "historic":
+            end_time = datetime.datetime.strftime(self.hist_end_date, "%Y%m%d 17:00:00")
+            self.ib_client.reqHistoricalData(
+                0, contract, end_time, self.hist_duration, self.hist_barsize,
+                "TRADES", True, 2, None)

--- a/qstrader/price_handler/ib_bar.py
+++ b/qstrader/price_handler/ib_bar.py
@@ -1,75 +1,115 @@
 import os
 import datetime
+import queue
 from .base import AbstractBarPriceHandler
+
+from qstrader.service.ib import IBService
 
 from ibapi.client import EClient
 from ibapi.wrapper import EWrapper
+from ibapi.utils import iswrapper
 from ibapi.contract import *
-
-import logging
-
-class IBClient(EClient):
-    def __init__(self, wrapper):
-        EClient.__init__(self, wrapper)
+from ibapi.common import *
 
 
-class IBWrapper(EWrapper):
-    def __init__(self):
-        EWrapper.__init__(self)
 
-    def historicalData(self, reqId:int, date:str, open:float, high:float,
-                        low: float, close:float, volume: int, barCount: int,
-                        WAP:float, hasGaps: int):
-        logging.error("RECEIVED HISTORICAL DATA BAR.")
+#types
+from ibapi.utils import (current_fn_name, BadMessage)
+from ibapi.common import *
+from ibapi.order_condition import *
+from ibapi.contract import *
+from ibapi.order import *
+from ibapi.order_state import *
+from ibapi.execution import Execution
+from ibapi.execution import ExecutionFilter
+from ibapi.commission_report import CommissionReport
+from ibapi.scanner import ScannerSubscription
+from ibapi.ticktype import *
+
+from ibapi.account_summary_tags import *
 
 
-class IBBarPriceHandler(AbstractBarPriceHandler, IBWrapper, IBClient):
+class IBBarPriceHandler(AbstractBarPriceHandler):
     """
     Designed to feed either live or historic market data bars
     from an Interactive Brokers connection.
 
-    Each "IB-connected" module requires its 'client' and 'wrapper' methods.
+    Uses the IBService to make requests and collect data once responses have returned.
 
     TODO:
         * Historic/Live mode to be set by whether QSTrader is in Backtest or Live mode
+        * IBService should be an initialization parameter
+        * Ports, etc, connection strings from config
     """
     def __init__(
-        self, events_queue, tickers, settings, mode="historic",
+        self, events_queue, param_tickers, settings, mode="historic",
         hist_end_date = datetime.datetime.now() - datetime.timedelta(days=3),
-        hist_duration="1 D", hist_barsize="1 min"
+        hist_duration="5 D", hist_barsize="1 min"
     ):
-        logging.basicConfig( level=logging.ERROR )
-
-        self.ib_wrapper = IBWrapper()
-        self.ib_client = IBClient(self.ib_wrapper)
-
-        self.ib_client.connect("127.0.0.1",4001,0)
-
-        self.tickers = {}
+        self.ib_service = IBService()
+        self.ib_service.connect("127.0.0.1",4001,0)
         self.mode = mode
         self.continue_backtest = True
         self.hist_end_date = hist_end_date
         self.hist_duration = hist_duration
         self.hist_barsize = hist_barsize
 
-        for ticker in tickers:
+        # The position of a ticker in this dict is used as its IB ID.
+        self.tickers = {} # TODO gross
+        self.ticker_lookup = {}
+
+        for ticker in param_tickers:  # TODO gross param_tickers -- combine above?
             self._subscribe_ticker(ticker)
 
-        import time
-        time.sleep(10)
+        self._wait_for_hist_population()
 
 
     def _subscribe_ticker(self, ticker):
+        """
+        Request ticker data from IB
+        """
         if ticker not in self.tickers:
             # Set up an IB ContractS
             contract = Contract()
             contract.exchange = "SMART"
             contract.symbol = ticker
             contract.secType = "STK"
-            contract.currency = "USD"
+            contract.currency = "AUD"
 
         if self.mode == "historic":
+            ib_ticker_id = len(self.tickers)
             end_time = datetime.datetime.strftime(self.hist_end_date, "%Y%m%d 17:00:00")
-            self.ib_client.reqHistoricalData(
-                0, contract, end_time, self.hist_duration, self.hist_barsize,
+            self.ib_service.reqHistoricalData(
+                ib_ticker_id, contract, end_time, self.hist_duration, self.hist_barsize,
                 "TRADES", True, 2, None)
+
+        # TODO gross
+        self.ticker_lookup[len(self.tickers)] = ticker
+        self.tickers[ticker] = {}
+
+
+    def _wait_for_hist_population(self):
+        """
+        # TODO this *needs* to be an infinite loop running inside the service,
+        # with the service launched on a new Thread or Process
+        """
+        while (self.ib_service.conn.isConnected() or not self.ib_service.msg_queue.empty()) and len(self.ib_service.waitingHistoricalData) != 0:
+            try:
+                text = self.ib_service.msg_queue.get(block=True, timeout=0.2)
+                if len(text) > MAX_MSG_LEN:
+                    self.ib_service.wrapper.error(NO_VALID_ID, BAD_LENGTH.code(),
+                        "%s:%d:%s" % (BAD_LENGTH.msg(), len(text), text))
+                    self.ib_service.disconnect()
+                    break
+            except queue.Empty:
+                print("queue.get: empty")
+            else:
+                fields = comm.read_fields(text)
+                print("fields %s", fields)
+                self.ib_service.decoder.interpret(fields)
+
+            print("conn:%d queue.sz:%d",
+                         self.ib_service.conn.isConnected(),
+                         self.ib_service.msg_queue.qsize())
+
+        self.ib_service.disconnect()

--- a/qstrader/service/ib.py
+++ b/qstrader/service/ib.py
@@ -52,31 +52,6 @@ class IBService(EWrapper, EClient):
         self.historicalDataQueue = queue.Queue()
         self.waitingHistoricalData = []
 
-        # Connect to IB and make the historic data request.
-        # self.connect("127.0.0.1", 4001, clientId=0)
-        # self.historicalDataRequests_req()
-        #
-        # while (self.conn.isConnected() or not self.msg_queue.empty()) and len(self.waitingHistoricalData) != 0:
-        #     try:
-        #         text = self.msg_queue.get(block=True, timeout=0.2)
-        #         if len(text) > MAX_MSG_LEN:
-        #             self.wrapper.error(NO_VALID_ID, BAD_LENGTH.code(),
-        #                 "%s:%d:%s" % (BAD_LENGTH.msg(), len(text), text))
-        #             self.disconnect()
-        #             break
-        #     except queue.Empty:
-        #         logging.debug("queue.get: empty")
-        #     else:
-        #         fields = comm.read_fields(text)
-        #         logging.debug("fields %s", fields)
-        #         self.decoder.interpret(fields)
-        #
-        #     # print("conn:%d queue.sz:%d",
-        #     #              self.conn.isConnected(),
-        #     #              self.msg_queue.qsize())
-        #
-        # self.disconnect()
-
 
     def error(self, reqId:TickerId, errorCode:int, errorString:str):
         super().error(reqId, errorCode, errorString)
@@ -102,7 +77,9 @@ class IBService(EWrapper, EClient):
     def historicalData(self, reqId:TickerId , date:str, open:float, high:float,
                        low:float, close:float, volume:int, barCount:int,
                         WAP:float, hasGaps:int):
-        print("RECEIVED HISTORIC DATA")
+        print("HistoricalData. ", reqId, " Date:", date, "Open:", open,
+            "High:", high, "Low:", low, "Close:", close, "Volume:", volume,
+            "Count:", barCount, "WAP:", WAP, "HasGaps:", hasGaps)
         self.historicalDataQueue.put((reqId, date, open, high, low, close,
                                         volume, barCount, WAP, hasGaps))
 

--- a/qstrader/service/ib.py
+++ b/qstrader/service/ib.py
@@ -9,7 +9,7 @@ import logging
 import time
 import os.path
 
-from ibapi.wrapper import wrapper
+from ibapi.wrapper import EWrapper
 from ibapi.client import EClient
 from ibapi.utils import iswrapper
 
@@ -28,14 +28,8 @@ from ibapi.ticktype import *
 
 from ibapi.account_summary_tags import *
 
-from ContractSamples import ContractSamples
-from OrderSamples import OrderSamples
-from AvailableAlgoParams import AvailableAlgoParams
-from ScannerSubscriptionSamples import ScannerSubscriptionSamples
-from FaAllocationSamples import FaAllocationSamples
 
-
-class IBService(IBWrapper, IBClient):
+class IBService(EWrapper, EClient):
     """
     The IBService is the primary conduit of data from QStrader to Interactive Brokers.
     This service provides functions to request data, and allows for
@@ -52,8 +46,8 @@ class IBService(IBWrapper, IBClient):
     can easily create mock instances of the IBService for testing.
     """
     def __init__(self):
-        IBWrapper.__init__(self)
-        IBClient.__init__(self, wrapper=self)
+        EWrapper.__init__(self)
+        EClient.__init__(self, wrapper=self)
 
         self.historicalDataQueue = queue.Queue()
         self.waitingHistoricalData = []

--- a/qstrader/services/ib.py
+++ b/qstrader/services/ib.py
@@ -1,0 +1,137 @@
+import sys
+import argparse
+import datetime
+import collections
+import inspect
+import queue
+
+import logging
+import time
+import os.path
+
+from ibapi.wrapper import wrapper
+from ibapi.client import EClient
+from ibapi.utils import iswrapper
+
+#types
+from ibapi.utils import (current_fn_name, BadMessage)
+from ibapi.common import *
+from ibapi.order_condition import *
+from ibapi.contract import *
+from ibapi.order import *
+from ibapi.order_state import *
+from ibapi.execution import Execution
+from ibapi.execution import ExecutionFilter
+from ibapi.commission_report import CommissionReport
+from ibapi.scanner import ScannerSubscription
+from ibapi.ticktype import *
+
+from ibapi.account_summary_tags import *
+
+from ContractSamples import ContractSamples
+from OrderSamples import OrderSamples
+from AvailableAlgoParams import AvailableAlgoParams
+from ScannerSubscriptionSamples import ScannerSubscriptionSamples
+from FaAllocationSamples import FaAllocationSamples
+
+
+class IBService(IBWrapper, IBClient):
+    """
+    The IBService is the primary conduit of data from QStrader to Interactive Brokers.
+    This service provides functions to request data, and allows for
+    callbacks to be triggered, which populates "data queues" with the response.
+
+    All methods of the EClient are available (i.e. API Requests), as are
+    the callbacks for EWrapper (i.e. API responses). It also provides a set of Queues
+    which are populated with the responses from EWrapper. Other components in the
+    system should use these queues collect the API response data.
+
+    Any module or component that wishes to interact with IB should do so by using
+    methods offered in this class. This ensures that the logic required to talk with IB
+    is contained within this class exclusively, with the added benefit that we
+    can easily create mock instances of the IBService for testing.
+    """
+    def __init__(self):
+        IBWrapper.__init__(self)
+        IBClient.__init__(self, wrapper=self)
+
+        self.historicalDataQueue = queue.Queue()
+        self.waitingHistoricalData = []
+
+        # Connect to IB and make the historic data request.
+        # self.connect("127.0.0.1", 4001, clientId=0)
+        # self.historicalDataRequests_req()
+        #
+        # while (self.conn.isConnected() or not self.msg_queue.empty()) and len(self.waitingHistoricalData) != 0:
+        #     try:
+        #         text = self.msg_queue.get(block=True, timeout=0.2)
+        #         if len(text) > MAX_MSG_LEN:
+        #             self.wrapper.error(NO_VALID_ID, BAD_LENGTH.code(),
+        #                 "%s:%d:%s" % (BAD_LENGTH.msg(), len(text), text))
+        #             self.disconnect()
+        #             break
+        #     except queue.Empty:
+        #         logging.debug("queue.get: empty")
+        #     else:
+        #         fields = comm.read_fields(text)
+        #         logging.debug("fields %s", fields)
+        #         self.decoder.interpret(fields)
+        #
+        #     # print("conn:%d queue.sz:%d",
+        #     #              self.conn.isConnected(),
+        #     #              self.msg_queue.qsize())
+        #
+        # self.disconnect()
+
+
+    def error(self, reqId:TickerId, errorCode:int, errorString:str):
+        super().error(reqId, errorCode, errorString)
+        print("Error. Id: " , reqId, " Code: " , errorCode , " Msg: " , errorString)
+
+
+    """
+    Append `reqId` to waitingHistoricalData, then call the super method.
+    """
+    def reqHistoricalData(self, reqId:TickerId , contract:Contract, endDateTime:str,
+                          durationStr:str, barSizeSetting:str, whatToShow:str,
+                          useRTH:int, formatDate:int, chartOptions:TagValueList):
+        self.waitingHistoricalData.append(reqId)
+        print("REQUESTING HISTORIC, WAITING FOR %s" % len(self.waitingHistoricalData))
+        super().reqHistoricalData( reqId, contract, endDateTime,
+                                  durationStr, barSizeSetting, whatToShow,
+                                  useRTH, formatDate, chartOptions)
+
+
+    """
+    Creates a historical data request for CBA.
+    """
+    def historicalDataRequests_req(self):
+        contract = Contract()
+        contract.exchange = "SMART"
+        contract.symbol = "CBA"
+        contract.secType = "STK"
+        contract.currency = "AUD"
+
+        queryTime = (datetime.datetime.today() -
+                    datetime.timedelta(days=180)).strftime("%Y%m%d %H:%M:%S")
+        self.reqHistoricalData(4002, contract, queryTime,
+                                "10 D", "1 min", "TRADES", 1, 1, None)
+
+
+    """
+    Populate the HistoricalData queue.
+    """
+    def historicalData(self, reqId:TickerId , date:str, open:float, high:float,
+                       low:float, close:float, volume:int, barCount:int,
+                        WAP:float, hasGaps:int):
+        print("RECEIVED HISTORIC DATA")
+        self.historicalDataQueue.put((reqId, date, open, high, low, close,
+                                        volume, barCount, WAP, hasGaps))
+
+    """
+    Remove `reqId` from waitingHistoricalData
+    TODO: Will it work with multiple historical requests for same symbol?
+    """
+    def historicalDataEnd(self, reqId:int, start:str, end:str):
+        print("FINISHED FOR %s" % reqId)
+        self.waitingHistoricalData.remove(reqId)

--- a/qstrader/services/ib.py
+++ b/qstrader/services/ib.py
@@ -103,22 +103,6 @@ class IBService(IBWrapper, IBClient):
 
 
     """
-    Creates a historical data request for CBA.
-    """
-    def historicalDataRequests_req(self):
-        contract = Contract()
-        contract.exchange = "SMART"
-        contract.symbol = "CBA"
-        contract.secType = "STK"
-        contract.currency = "AUD"
-
-        queryTime = (datetime.datetime.today() -
-                    datetime.timedelta(days=180)).strftime("%Y%m%d %H:%M:%S")
-        self.reqHistoricalData(4002, contract, queryTime,
-                                "10 D", "1 min", "TRADES", 1, 1, None)
-
-
-    """
     Populate the HistoricalData queue.
     """
     def historicalData(self, reqId:TickerId , date:str, open:float, high:float,

--- a/tests/test_ib_price_handler.py
+++ b/tests/test_ib_price_handler.py
@@ -4,7 +4,6 @@ from qstrader.price_handler.ib_bar import IBBarPriceHandler
 from qstrader.compat import queue
 from qstrader import settings
 
-
 class TestPriceHandlerSimpleCase(unittest.TestCase):
     def setUp(self):
         """
@@ -14,7 +13,7 @@ class TestPriceHandlerSimpleCase(unittest.TestCase):
         self.config = settings.TEST
         fixtures_path = self.config.CSV_DATA_DIR
         events_queue = queue.Queue()
-        init_tickers = ["FB"]
+        init_tickers = ["CBA"]
         self.price_handler = IBBarPriceHandler(
             events_queue, init_tickers, self.config
         )

--- a/tests/test_ib_price_handler.py
+++ b/tests/test_ib_price_handler.py
@@ -1,0 +1,28 @@
+import unittest
+
+from qstrader.price_handler.ib_bar import IBBarPriceHandler
+from qstrader.compat import queue
+from qstrader import settings
+
+
+class TestPriceHandlerSimpleCase(unittest.TestCase):
+    def setUp(self):
+        """
+        Set up the PriceHandler object with a small
+        set of initial tickers for a backtest in historic mode.
+        """
+        self.config = settings.TEST
+        fixtures_path = self.config.CSV_DATA_DIR
+        events_queue = queue.Queue()
+        init_tickers = ["FB"]
+        self.price_handler = IBBarPriceHandler(
+            events_queue, init_tickers, self.config
+        )
+
+    def test(self):
+        self.assertEqual(1,2)
+
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Starting this as a long-running branch. Expect it to be merged when *at least* the `IBService` is capable of running an infinite loop without blocking the QSTrader `trading_session`. 

More discussions in Slack for reasoning &  alternate approaches, but for the record:

IBService abstracts away communication and message handling of the Python/IB API. Mainly because it has this annoying blocking infinite loop, which the Swigibpy version also had, but in a separate process.

Any component in QSTrader that wishes to interact with IB needs to go through the IBService. Call the Python API client methods on the IBService. IBService implements the EWrapper overrides that allow the IB responses to come back. All data that comes back from IB should be stored in Queues (or some other data structure) which are members of the IBService. Each component should look for the data it requested inside the appropriate queue (i.e. historic bars, market bars, portfolio updates, etc).

A nice bonus with this approach is that mocking IB for the purposes of testing any IBComponent (`IBPriceHandler`, `IBExecutionHandler`, etc) is simply a case of providing stub EClient methods, and returning some dummy data in the Queues that would normally be filled by the IB Response.