### PR TITLE
Live trade session

### DIFF
--- a/examples/buy_and_hold_backtest.py
+++ b/examples/buy_and_hold_backtest.py
@@ -4,7 +4,7 @@ from qstrader import settings
 from qstrader.strategy.base import AbstractStrategy
 from qstrader.event import SignalEvent, EventType
 from qstrader.compat import queue
-from qstrader.trading_session.backtest import Backtest
+from qstrader.trading_session import TradingSession
 
 
 class BuyAndHoldStrategy(AbstractStrategy):
@@ -50,12 +50,12 @@ def run(config, testing, tickers, filename):
     strategy = BuyAndHoldStrategy(tickers[0], events_queue)
 
     # Set up the backtest
-    backtest = Backtest(
+    backtest = TradingSession(
         config, strategy, tickers,
         initial_equity, start_date, end_date,
         events_queue, title=title
     )
-    results = backtest.simulate_trading(testing=testing)
+    results = backtest.start_trading(testing=testing)
     return results
 
 

--- a/examples/monthly_liquidate_rebalance_backtest.py
+++ b/examples/monthly_liquidate_rebalance_backtest.py
@@ -6,7 +6,7 @@ from qstrader.strategy.base import AbstractStrategy
 from qstrader.position_sizer.rebalance import LiquidateRebalancePositionSizer
 from qstrader.event import SignalEvent, EventType
 from qstrader.compat import queue
-from qstrader.trading_session.backtest import Backtest
+from qstrader.trading_session import TradingSession
 
 
 class MonthlyLiquidateRebalanceStrategy(AbstractStrategy):
@@ -87,13 +87,13 @@ def run(config, testing, tickers, filename):
     )
 
     # Set up the backtest
-    backtest = Backtest(
+    backtest = TradingSession(
         config, strategy, tickers,
         initial_equity, start_date, end_date,
         events_queue, position_sizer=position_sizer,
         title=title, benchmark=tickers[0],
     )
-    results = backtest.simulate_trading(testing=testing)
+    results = backtest.start_trading(testing=testing)
     return results
 
 

--- a/examples/moving_average_cross_backtest.py
+++ b/examples/moving_average_cross_backtest.py
@@ -7,7 +7,7 @@ from qstrader import settings
 from qstrader.strategy.base import AbstractStrategy
 from qstrader.event import SignalEvent, EventType
 from qstrader.compat import queue
-from qstrader.trading_session.backtest import Backtest
+from qstrader.trading_session import TradingSession
 
 
 class MovingAverageCrossStrategy(AbstractStrategy):
@@ -87,13 +87,13 @@ def run(config, testing, tickers, filename):
     )
 
     # Set up the backtest
-    backtest = Backtest(
+    backtest = TradingSession(
         config, strategy, tickers,
         initial_equity, start_date, end_date,
         events_queue, title=title,
         benchmark=tickers[1],
     )
-    results = backtest.simulate_trading(testing=testing)
+    results = backtest.start_trading(testing=testing)
     return results
 
 

--- a/qstrader/trading_session.py
+++ b/qstrader/trading_session.py
@@ -1,15 +1,15 @@
 from __future__ import print_function
-
-from ..compat import queue
-from ..event import EventType
-from ..price_handler.yahoo_daily_csv_bar import YahooDailyCsvBarPriceHandler
-from ..price_parser import PriceParser
-from ..position_sizer.fixed import FixedPositionSizer
-from ..risk_manager.example import ExampleRiskManager
-from ..portfolio_handler import PortfolioHandler
-from ..compliance.example import ExampleCompliance
-from ..execution_handler.ib_simulated import IBSimulatedExecutionHandler
-from ..statistics.tearsheet import TearsheetStatistics
+from datetime import datetime
+from .compat import queue
+from .event import EventType
+from .price_handler.yahoo_daily_csv_bar import YahooDailyCsvBarPriceHandler
+from .price_parser import PriceParser
+from .position_sizer.fixed import FixedPositionSizer
+from .risk_manager.example import ExampleRiskManager
+from .portfolio_handler import PortfolioHandler
+from .compliance.example import ExampleCompliance
+from .execution_handler.ib_simulated import IBSimulatedExecutionHandler
+from .statistics.tearsheet import TearsheetStatistics
 
 
 class TradingSession(object):
@@ -49,11 +49,11 @@ class TradingSession(object):
         self.title = title
         self.benchmark = benchmark
         self.session_type = session_type
-        self._config_backtest()
+        self._config_session()
         self.cur_time = None
 
         if self.session_type == "live":
-            if self.end_session_time == None:
+            if self.end_session_time is None:
                 raise Exception("Must specify an end_session_time when live trading")
 
     def _config_session(self):
@@ -149,7 +149,7 @@ class TradingSession(object):
                     else:
                         raise NotImplemented("Unsupported event.type '%s'" % event.type)
 
-    def do_trading(self, testing=False):
+    def start_trading(self, testing=False):
         """
         Runs either a backtest or live session, and outputs performance when complete.
         """

--- a/qstrader/trading_session/backtest.py
+++ b/qstrader/trading_session/backtest.py
@@ -12,14 +12,15 @@ from ..execution_handler.ib_simulated import IBSimulatedExecutionHandler
 from ..statistics.tearsheet import TearsheetStatistics
 
 
-class Backtest(object):
+class TradingSession(object):
     """
     Enscapsulates the settings and components for
-    carrying out an event-driven backtest.
+    carrying out either a backtest or live trading session.
     """
     def __init__(
         self, config, strategy, tickers,
         equity, start_date, end_date, events_queue,
+        session_type="backtest", end_session_time=None,
         price_handler=None, portfolio_handler=None,
         compliance=None, position_sizer=None,
         execution_handler=None, risk_manager=None,
@@ -47,15 +48,20 @@ class Backtest(object):
         self.sentiment_handler = sentiment_handler
         self.title = title
         self.benchmark = benchmark
+        self.session_type = session_type
         self._config_backtest()
         self.cur_time = None
 
-    def _config_backtest(self):
+        if self.session_type == "live":
+            if self.end_session_time == None:
+                raise Exception("Must specify an end_session_time when live trading")
+
+    def _config_session(self):
         """
         Initialises the necessary classes used
-        within the backtest.
+        within the session.
         """
-        if self.price_handler is None:
+        if self.price_handler is None and self.session_type == "backtest":
             self.price_handler = YahooDailyCsvBarPriceHandler(
                 self.config.CSV_DATA_DIR, self.events_queue,
                 self.tickers, start_date=self.start_date,
@@ -93,7 +99,13 @@ class Backtest(object):
                 self.title, self.benchmark
             )
 
-    def _run_backtest(self):
+    def _continue_loop_condition(self):
+        if self.session_type == "backtest":
+            return self.price_handler.continue_backtest
+        else:
+            return datetime.now() < self.end_session_time
+
+    def _run_session(self):
         """
         Carries out an infinite while loop that polls the
         events queue and directs each event to either the
@@ -101,8 +113,12 @@ class Backtest(object):
         loop continue until the event queue has been
         emptied.
         """
-        print("Running Backtest...")
-        while self.price_handler.continue_backtest:
+        if self.session_type == "backtest":
+            print("Running Backtest...")
+        else:
+            print("Running Realtime Session until %s" % self.end_session_time)
+
+        while self._continue_loop_condition():
             try:
                 event = self.events_queue.get(False)
             except queue.Empty:
@@ -133,11 +149,11 @@ class Backtest(object):
                     else:
                         raise NotImplemented("Unsupported event.type '%s'" % event.type)
 
-    def simulate_trading(self, testing=False):
+    def do_trading(self, testing=False):
         """
-        Simulates the backtest and outputs portfolio performance.
+        Runs either a backtest or live session, and outputs performance when complete.
         """
-        self._run_backtest()
+        self._run_session()
         results = self.statistics.get_results()
         print("---------------------------------")
         print("Backtest complete.")


### PR DESCRIPTION
Minor refactor of the original `backtest.py` class to also allow for live trading. Live trading only differs in that it's "end-condition" is the passing of time, until and `end_session_time`. All loop logic remains the same.

This branch is a dependancy of https://github.com/mhallsmoore/qstrader/pull/186. I created a new branch here as the logic has no overlap with IB integration.

I'm suggesting we don't do the `IBService` setup/teardown in the `TradingSession` -- we must do it in the setup scripts where the user defines their strategy, symbols, handlers, etc.

Otherwise we need to create a `TradingSession` for each service, or create an abstraction where we take in a list of services (unnecessarily complex). As it stands, the `TradingSession` simply takes in a set of QSTrader components (price, risk, execution handlers, etc) -- each of these components may have services/external system dependancies, but the trading loop does not -and should not- care.

Would appreciate prompt integration with master so I can get cracking with live market data in the IB-PriceHandler