### PR TITLE
Add filename to trigger save plot

### DIFF
--- a/qstrader/statistics/tearsheet.py
+++ b/qstrader/statistics/tearsheet.py
@@ -648,4 +648,4 @@ class TearsheetStatistics(AbstractStatistics):
 
     def save(self, filename=""):
         filename = self.get_filename(filename)
-        self.plot_results
+        self.plot_results(filename)


### PR DESCRIPTION
It seems that the filename parameter needs to be passed to plot_results call inside the save function to trigger saving of the plot.