### PR TITLE
Simplified the calculation of total portfolio value in Portfolio

### DIFF
--- a/qstrader/portfolio.py
+++ b/qstrader/portfolio.py
@@ -39,9 +39,7 @@ class Portfolio(object):
                 ask = close_price
             pt.update_market_value(bid, ask)
             self.unrealised_pnl += pt.unrealised_pnl
-            self.equity += (
-                pt.market_value - pt.cost_basis + pt.realised_pnl
-            )
+            self.equity += pt.unrealised_pnl + pt.realised_pnl
 
     def _add_position(
         self, action, ticker,


### PR DESCRIPTION
The value of ``self.equity`` is incremented by the position's P&L. In my opinion there is no need to calculate unrealised P&L once again, since there is already a field for that in the ``Position`` class. The field is updated on each ``Position.update_market_value()`` call.