### PR TITLE
Attempted fix for end-to-end backtest integration test failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 
 before_install:
   - export PYTHONPATH=$PYTHONPATH:$(pwd) 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 Click>=7.0
 matplotlib>=3.0.3,!=3.3.3
 numpy>=1.17.1
-pandas>=0.25.1
+pandas>=1.1.5
 seaborn>=0.9.0

--- a/tests/integration/trading/test_backtest_e2e.py
+++ b/tests/integration/trading/test_backtest_e2e.py
@@ -2,6 +2,7 @@ import os
 
 import pandas as pd
 import pytz
+import pytest
 
 from qstrader.alpha_model.fixed_signals import FixedSignalsAlphaModel
 from qstrader.asset.universe.static import StaticUniverse
@@ -63,7 +64,15 @@ def test_backtest_sixty_forty(etf_filepath):
     expected_df = pd.read_csv(os.path.join(etf_filepath, 'sixty_forty_history.dat'))
 
     pd.testing.assert_frame_equal(history_df, expected_df)
-    assert portfolio_dict == expected_dict
+
+    # Necessary as test fixtures differ between
+    # Pandas 1.1.5 and 1.2.0 very slightly
+    for symbol in expected_dict.keys():
+        for metric in expected_dict[symbol].keys():
+            assert pytest.approx(
+                portfolio_dict[symbol][metric],
+                expected_dict[symbol][metric]
+            )
 
 
 def test_backtest_long_short_leveraged(etf_filepath):


### PR DESCRIPTION
**Overview**

This PR provides a fix for Issue #349, which occured because of a Pandas version change between Python 3.6 and 3.7 in the TravisCI continuous integration tests.

It includes:

- Dropping support for Python 3.5, since the version is now not officially supported any more.
- Adding support for Python 3.9.
- Bumping the required version of Pandas to >= 1.1.5.
- Utilising the ``pytest.approx`` method to check for 'equality' between the test fixture and the backtest result to fix the ``AssertionError``.