### PR TITLE
added example of json statistics usage to examples folder, added para…

### DIFF
--- a/examples/buy_and_hold_to_json_file.py
+++ b/examples/buy_and_hold_to_json_file.py
@@ -1,0 +1,51 @@
+import os
+
+import pandas as pd
+import pytz
+
+from qstrader.alpha_model.fixed_signals import FixedSignalsAlphaModel
+from qstrader.asset.equity import Equity
+from qstrader.asset.universe.static import StaticUniverse
+from qstrader.data.backtest_data_handler import BacktestDataHandler
+from qstrader.data.daily_bar_csv import CSVDailyBarDataSource
+from qstrader.statistics.json_statistics import JSONStatistics
+from qstrader.trading.backtest import BacktestTradingSession
+
+
+if __name__ == "__main__":
+    start_dt = pd.Timestamp('2004-11-19 14:30:00', tz=pytz.UTC)
+    end_dt = pd.Timestamp('2019-12-31 23:59:00', tz=pytz.UTC)
+
+    # Construct the symbol and asset necessary for the backtest
+    strategy_symbols = ['GLD']
+    strategy_assets = ['EQ:GLD']
+    strategy_universe = StaticUniverse(strategy_assets)
+
+    # To avoid loading all CSV files in the directory, set the
+    # data source to load only those provided symbols
+    csv_dir = os.environ.get('QSTRADER_CSV_DATA_DIR', '.')
+    data_source = CSVDailyBarDataSource(csv_dir, Equity, csv_symbols=strategy_symbols)
+    data_handler = BacktestDataHandler(strategy_universe, data_sources=[data_source])
+
+    # Construct an Alpha Model that simply provides a fixed
+    # signal for the single GLD ETF at 100% allocation
+    # with a backtest that does not rebalance
+    strategy_alpha_model = FixedSignalsAlphaModel({'EQ:GLD': 1.0})
+    strategy_backtest = BacktestTradingSession(
+        start_dt,
+        end_dt,
+        strategy_universe,
+        strategy_alpha_model,
+        rebalance='buy_and_hold',
+        long_only=True,
+        cash_buffer_percentage=0.01,
+        data_handler=data_handler
+    )
+    strategy_backtest.run()
+
+    # Performance Output to file in JSON Format
+    json_stats = JSONStatistics(
+        equity_curve=strategy_backtest.get_equity_curve(),
+        target_allocations=strategy_backtest.get_target_allocations()
+    )
+    json_stats.to_file()

--- a/qstrader/statistics/json_statistics.py
+++ b/qstrader/statistics/json_statistics.py
@@ -16,6 +16,8 @@ class JSONStatistics(object):
     ----------
     equity_curve : `pd.DataFrame`
         The equity curve DataFrame indexed by date-time.
+    target_allocations : `pd.DataFrame`
+        The target allocations DataFrame indexed by date-time.
     strategy_id : `str`, optional
         The optional ID string for the strategy to pass to
         the statistics dict.


### PR DESCRIPTION
JSONStatistics class was missing documentation for the required variable target_allocation which resulted in an error when used in the same way as TearsheetStatistics.

I added documentation for the variable, and added an example using JSONStatistics to examples/ which makes usage of the class clearer to users.