### PR TITLE
Removed not implemented methods from broker.py

### DIFF
--- a/qstrader/broker/broker.py
+++ b/qstrader/broker/broker.py
@@ -47,12 +47,6 @@ class Broker(object):
         )
 
     @abstractmethod
-    def get_account_total_non_cash_equity(self):
-        raise NotImplementedError(
-            "Should implement get_account_total_non_cash_equity()"
-        )
-
-    @abstractmethod
     def get_account_total_equity(self):
         raise NotImplementedError(
             "Should implement get_account_total_equity()"
@@ -86,12 +80,6 @@ class Broker(object):
     def get_portfolio_cash_balance(self, portfolio_id):
         raise NotImplementedError(
             "Should implement get_portfolio_cash_balance()"
-        )
-
-    @abstractmethod
-    def get_portfolio_total_non_cash_equity(self, portfolio_id):
-        raise NotImplementedError(
-            "Should implement get_portfolio_total_non_cash_equity()"
         )
 
     @abstractmethod


### PR DESCRIPTION
This PR makes the following changes:
* removes get_account_total_non_cash_equity
* removes get_portfolio_total_non_cash_equity

Both were present in the abstract base class, neither method has been implemented and are not required.