### PR TITLE
Qs38 buy and hold rebalance business day

### DIFF
--- a/qstrader/system/rebalance/buy_and_hold.py
+++ b/qstrader/system/rebalance/buy_and_hold.py
@@ -1,10 +1,12 @@
+import pandas as pd
+from pandas.tseries.offsets import BusinessDay
 from qstrader.system.rebalance.rebalance import Rebalance
 
 
 class BuyAndHoldRebalance(Rebalance):
     """
-    Generates a single rebalance timestamp at the start date in
-    order to create a single set of orders at the beginning of
+    Generates a single rebalance timestamp at the first business day 
+    after the start date. Creates a single set of orders at the beginning of
     a backtest, with no further rebalances carried out.
 
     Parameters
@@ -15,4 +17,32 @@ class BuyAndHoldRebalance(Rebalance):
 
     def __init__(self, start_dt):
         self.start_dt = start_dt
-        self.rebalances = [start_dt]
+        self.rebalances = self._generate_rebalances()
+
+    def _is_business_day(self):
+        """
+        Checks if the start_dt is a business day.
+        
+        Returns
+        -------
+        `boolean`
+        """
+        return bool(len(pd.bdate_range(self.start_dt, self.start_dt)))
+
+    def _generate_rebalances(self):
+        """
+        Outputs the rebalance timestamp offset to the next
+        business day.
+
+        Does not include holidays.
+
+        Returns
+        -------
+        `list[pd.Timestamp]`
+            The rebalance timestamp list.
+        """
+        if not self._is_business_day():
+            rebalance_date = self.start_dt + BusinessDay()
+        else:
+            rebalance_date = self.start_dt
+        return [rebalance_date]

--- a/tests/integration/trading/test_backtest_e2e.py
+++ b/tests/integration/trading/test_backtest_e2e.py
@@ -140,7 +140,7 @@ def test_backtest_buy_and_hold(etf_filepath, capsys):
     universe = StaticUniverse(assets)
     alpha_model = FixedSignalsAlphaModel({'EQ:GHI':1.0})
     
-    start_dt = pd.Timestamp('2015-11-09 14:30:00', tz=pytz.UTC)
+    start_dt = pd.Timestamp('2015-11-07 14:30:00', tz=pytz.UTC)
     end_dt = pd.Timestamp('2015-11-10 14:30:00', tz=pytz.UTC)
 
     backtest = BacktestTradingSession(

--- a/tests/integration/trading/test_backtest_e2e.py
+++ b/tests/integration/trading/test_backtest_e2e.py
@@ -133,6 +133,9 @@ def test_backtest_long_short_leveraged(etf_filepath):
 
 def test_backtest_buy_and_hold(etf_filepath, capsys):
     """
+    Ensures a backtest with a buy and hold rebalance calculates
+    the correct dates for execution orders when the start date is not
+    a business day.
     """
     settings.print_events=True
     os.environ['QSTRADER_CSV_DATA_DIR'] = etf_filepath

--- a/tests/unit/system/rebalance/test_buy_and_hold_rebalance.py
+++ b/tests/unit/system/rebalance/test_buy_and_hold_rebalance.py
@@ -6,15 +6,22 @@ from qstrader.system.rebalance.buy_and_hold import BuyAndHoldRebalance
 
 
 @pytest.mark.parametrize(
-    "start_dt", [('2020-01-01'), ('2020-02-02')]
+    "start_dt, reb_dt", [
+        ('2020-01-01', '2020-01-01'), 
+        ('2020-02-02', '2020-02-03')
+    ],
 )
-def test_buy_and_hold_rebalance(start_dt):
+def test_buy_and_hold_rebalance(start_dt, reb_dt):
     """
     Checks that the buy and hold rebalance sets the
-    appropriate internal attributes.
+    appropriate rebalance dates, both for a business and 
+    a non-business day.
+
+    Does not include holidays.
     """
     sd = pd.Timestamp(start_dt, tz=pytz.UTC)
+    rd = pd.Timestamp(reb_dt, tz=pytz.UTC)
     reb = BuyAndHoldRebalance(start_dt=sd)
 
     assert reb.start_dt == sd
-    assert reb.rebalances == [sd]
+    assert reb.rebalances == [rd]


### PR DESCRIPTION
This PR makes the following changes:
* Updates rebalance_buy_and_hold to check if the start_dt is a business day
    * If `start_dt` is a business day `rebalance_dates =  [start_dt]`
    * If `start_dt` is a weekend `rebalance_dates` = `[next business day]` 
* Adds  a unit test to check that the buisness day calculation is correct
* Adds an integration test to check that a backtest using `buy_and_hold_rebalance` generates execution orders on the correct dates 