### PR TITLE
Qs649 update backtest target allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.8
+
+* Updates BacktestTradingSession.get_target_allocations() to use burn_in_dt.date() instead of burn_in_dt Timestamp. Previous method compared a Timestamp to a datetime.date.
+* Adds an integration test to check that target allocations match the expected output, including a date index.
+
 # 0.2.7
 
 * Updates the execution handler to update final orders ensuring an execution order is created in the event of a single submission without a further rebalance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qstrader"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
     "click>=8.1",
     "matplotlib>=3.8",

--- a/qstrader/trading/backtest.py
+++ b/qstrader/trading/backtest.py
@@ -362,7 +362,7 @@ class BacktestTradingSession(TradingSession):
         alloc_df.index = alloc_df.index.date
         alloc_df = alloc_df.reindex(index=equity_curve.index, method='ffill')
         if self.burn_in_dt is not None:
-            alloc_df = alloc_df[self.burn_in_dt:]
+            alloc_df = alloc_df[self.burn_in_dt.date():]
         return alloc_df
 
     def run(self, results=False):


### PR DESCRIPTION
This PR makes the following changes:
* Converts burn_in_dt timestamp to date in BacktestTradingSession.get_target_allocations() line 365
* Adds integration test to confirm target allocation match expected output
* Bumps QSTrader version to 0.2.8