### PR TITLE
Qs651 qstv0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.9
+
+* Updates requirements file to use numpy v1.26.4 or lower. This is the last version of QSTrader that supports numpy<2.0.0.
+
 # 0.2.8
 
 * Updates BacktestTradingSession.get_target_allocations() to use burn_in_dt.date() instead of burn_in_dt Timestamp. Previous method compared a Timestamp to a datetime.date.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qstrader"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
     "click>=8.1",
     "matplotlib>=3.8",
-    "numpy>=1.26",
+    "numpy<=1.26.4",
     "pandas>=2.2",
     "seaborn>=0.13",
 ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 click>=8.0
 matplotlib>=3.8
-numpy>=1.26
+numpy>=1.26,<2.0.0
 pandas>=2.2
 seaborn>=0.13

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 click>=8.0
 matplotlib>=3.8
-numpy>=1.26,<2.0.0
+numpy<=1.26.4
 pandas>=2.2
 seaborn>=0.13


### PR DESCRIPTION
This PR makes the following changes:
* Updates requirements to use numpy<=1.26.4
* Updates version number
* Updates changelog

This is the last version of QSTrader that supports numpy <2.0.0