### PR TITLE
Updated pypi package to qstrader 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.3.0
+
+* Updates dependencies to use numpy v2.0.0. 
+* Updates simulated_broker.py to change np.NaN to np.nan
+* Updates backtest_data_handler.py to change np.NaN to np.nan
+* Updates daily_bar_csv.py to change np.NaN to np.nan
+* Updates tests
+
 # 0.2.9
 
 * Updates requirements file to use numpy v1.26.4 or lower. This is the last version of QSTrader that supports numpy<2.0.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qstrader"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
     "click>=8.1",
     "matplotlib>=3.8",
-    "numpy<=1.26.4",
+    "numpy>=2.0.0",
     "pandas>=2.2",
     "seaborn>=0.13",
 ]

--- a/qstrader/broker/simulated_broker.py
+++ b/qstrader/broker/simulated_broker.py
@@ -567,7 +567,7 @@ class SimulatedBroker(Broker):
         bid_ask = self.data_handler.get_asset_latest_bid_ask_price(
             dt, order.asset
         )
-        if bid_ask == (np.NaN, np.NaN):
+        if bid_ask == (np.nan, np.nan):
             raise ValueError(price_err_msg)
 
         # Calculate the consideration and total commission

--- a/qstrader/data/backtest_data_handler.py
+++ b/qstrader/data/backtest_data_handler.py
@@ -17,28 +17,28 @@ class BacktestDataHandler(object):
         """
         """
         # TODO: Check for asset in Universe
-        bid = np.NaN
+        bid = np.nan
         for ds in self.data_sources:
             try:
                 bid = ds.get_bid(dt, asset_symbol)
                 if not np.isnan(bid):
                     return bid
             except Exception:
-                bid = np.NaN
+                bid = np.nan
         return bid
 
     def get_asset_latest_ask_price(self, dt, asset_symbol):
         """
         """
         # TODO: Check for asset in Universe
-        ask = np.NaN
+        ask = np.nan
         for ds in self.data_sources:
             try:
                 ask = ds.get_ask(dt, asset_symbol)
                 if not np.isnan(ask):
                     return ask
             except Exception:
-                ask = np.NaN
+                ask = np.nan
         return ask
 
     def get_asset_latest_bid_ask_price(self, dt, asset_symbol):
@@ -61,7 +61,7 @@ class BacktestDataHandler(object):
             mid = (bid_ask[0] + bid_ask[1]) / 2.0
         except Exception:
             # TODO: Log this
-            mid = np.NaN
+            mid = np.nan
         return mid
 
     def get_assets_historical_range_close_price(

--- a/qstrader/data/daily_bar_csv.py
+++ b/qstrader/data/daily_bar_csv.py
@@ -219,7 +219,7 @@ class CSVDailyBarDataSource(object):
         try:
             bid = bid_series.iloc[0]
         except KeyError:  # Before start date
-            return np.NaN
+            return np.nan
         return bid
 
     @functools.lru_cache(maxsize=1024 * 1024)
@@ -244,7 +244,7 @@ class CSVDailyBarDataSource(object):
         try:
             ask = ask_series.iloc[0]
         except KeyError:  # Before start date
-            return np.NaN
+            return np.nan
         return ask
 
     def get_assets_historical_closes(self, start_dt, end_dt, assets):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 click>=8.0
 matplotlib>=3.8
-numpy<=1.26.4
+numpy>=2.0.0
 pandas>=2.2
 seaborn>=0.13

--- a/tests/unit/broker/test_simulated_broker.py
+++ b/tests/unit/broker/test_simulated_broker.py
@@ -13,7 +13,7 @@ from qstrader import settings
 
 class ExchangeMock(object):
     def get_latest_asset_bid_ask(self, asset):
-        return (np.NaN, np.NaN)
+        return (np.nan, np.nan)
 
     def is_open_at_datetime(self, dt):
         return True
@@ -34,10 +34,10 @@ class ExchangeMockPrice(object):
 
 class DataHandlerMock(object):
     def get_asset_latest_bid_ask_price(self, dt, asset):
-        return (np.NaN, np.NaN)
+        return (np.nan, np.nan)
 
     def get_asset_latest_mid_price(self, dt, asset):
-        return np.NaN
+        return np.nan
 
 
 class DataHandlerMockPrice(object):
@@ -570,7 +570,7 @@ def test_submit_order():
     """
     Tests the execute_order method for:
     * Raises ValueError if no portfolio_id
-    * Raises ValueError if bid/ask is (np.NaN, np.NaN)
+    * Raises ValueError if bid/ask is (np.nan, np.nan)
     * Checks that bid/ask are correctly set dependent
     upon order direction
     * Checks that portfolio values are correct after
@@ -589,7 +589,7 @@ def test_submit_order():
     with pytest.raises(KeyError):
         sb.submit_order("1234", order)
 
-    # Raises ValueError if bid/ask is (np.NaN, np.NaN)
+    # Raises ValueError if bid/ask is (np.nan, np.nan)
     exchange_exception = ExchangeMockException()
     sbnp = SimulatedBroker(start_dt, exchange_exception, data_handler)
     sbnp.create_portfolio(portfolio_id=1234, name="My Portfolio #1")


### PR DESCRIPTION
This PR makes the following changes:
* Updates dependencies to use numpy>=2.0.0
* Updates simulated_broker.py to change np.NaN to np.nan
* Updates backtest_data_handler.py to change np.NaN to np.nan
* Updates daily_bar_csv.py to change np.NaN to np.nan
* Updates tests
